### PR TITLE
feat(micro): add print resume functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,16 @@ Whilst this repo does carry a firmware binary for the ESP32-C3 Generic board I s
 
 Key files:
 
-- `micro/main.py` - board entry point and application loop.
+- `micro/main.py` - board entry point and application loop; handles button presses, status polling, resume/plate-clear logic, and LED control.
 - `micro/config.json` - runtime configuration loaded by the board at boot.
 - `micro/config_loader.py` - config loader with defaults.
 - `micro/api.py` - low-level API-key HTTP client.
-- `micro/bambuddy_api.py` - route-level Bambuddy API wrapper.
+- `micro/bambuddy_api.py` - route-level Bambuddy API wrapper (status, resume, plate clear).
 - `micro/wifi.py` - Wi-Fi connection helper.
 - `micro/gpio_button.py` - debounced GPIO interrupt button helper.
-- `micro/led_flasher.py` - timer-driven LED flasher.
+- `micro/led_flasher.py` - timer-driven LED flasher with dynamic intervals (slow for pause, fast for plate clear).
+- `micro/printer_status.py` - printer state enum (PAUSE, PRINTING, FINISHED, IDLE).
+- `micro/periodic_timer.py` - periodic timer for status polling.
 - `firmware/ESP32_GENERIC_C3-20260406-v1.28.0.bin` - bundled ESP32-C3 MicroPython firmware image.
 - `scripts/push_micro.py` - copies required MicroPython files to the board with `mpremote`.
 - `scripts/run_main.py` - runs `micro/main.py` on the board without copying it as an auto-start file.

--- a/micro/bambuddy_api.py
+++ b/micro/bambuddy_api.py
@@ -85,3 +85,6 @@ class BambuddyAPI(API):
     def chamber_light_is_lit(self, printer_id):
         status = self.get_printer_status(printer_id)
         return status.get("chamber_light", False)
+
+    def resume_print(self, printer_id):
+        return self._post(f"printers/{printer_id}/print/resume")

--- a/micro/led_flasher.py
+++ b/micro/led_flasher.py
@@ -31,6 +31,10 @@ class LedFlasher:
     def off(self):
         self.led.value(0)
 
+    def set_interval(self, interval_ms):
+        self.interval_ms = interval_ms
+        self.timer.set_period(interval_ms)
+
     def _tick(self):
         if self.should_flash():
             self.led.value(not self.led.value())

--- a/micro/main.py
+++ b/micro/main.py
@@ -5,12 +5,14 @@ import gpio_button
 import led_flasher
 import wifi
 import periodic_timer
+import printer_status
 
 
 config = config_loader.load_config()
 
 # -- Runtime Flags ---
 PRINTER_AWAITING_PLATE_CLEAR = False
+PRINTER_STATUS = printer_status.PrinterStatus.IDLE
 PENDING_BUTTON_PRESS = False
 CHAMBER_LIGHT_IS_ON = True
 PRINTER_STATUS_UPDATE_REQUIRED = True
@@ -18,7 +20,7 @@ PRINTER_STATUS_UPDATE_REQUIRED = True
 # -- Initialize LED flasher ---
 flasher = led_flasher.LedFlasher(
     pin_number=config["led"]["pin"],
-    should_flash=lambda: PRINTER_AWAITING_PLATE_CLEAR,
+    should_flash=lambda: PRINTER_STATUS == printer_status.PrinterStatus.PAUSE or PRINTER_AWAITING_PLATE_CLEAR,
     interval_ms=config["led"]["flash_interval_ms"],
     inactive_value=lambda: CHAMBER_LIGHT_IS_ON,
 )
@@ -83,8 +85,18 @@ def handle_pending_button_press():
     global PENDING_BUTTON_PRESS
     global PRINTER_AWAITING_PLATE_CLEAR
     global PRINTER_STATUS_UPDATE_REQUIRED
+    global PRINTER_STATUS
 
-    if PRINTER_AWAITING_PLATE_CLEAR:
+    if PRINTER_STATUS == printer_status.PrinterStatus.PAUSE:
+        try:
+            api.resume_print(config["printer"]["id"])
+            PRINTER_STATUS_UPDATE_REQUIRED = True
+            print("Sent resume request")
+
+        except Exception as exc:
+            print("Failed to send resume request:", exc)
+
+    elif PRINTER_AWAITING_PLATE_CLEAR:
         try:
             PRINTER_AWAITING_PLATE_CLEAR = False
             api.clear_plate(config["printer"]["id"])
@@ -94,21 +106,27 @@ def handle_pending_button_press():
             print("Failed to send plate clear request:", exc)
 
     else:
-        print("Button press ignored - printer not awaiting plate clear")
+        print("Button press ignored - printer not paused or awaiting plate clear")
 
     PENDING_BUTTON_PRESS = False
 
 
 def handle_printer_status_update():
     global PRINTER_AWAITING_PLATE_CLEAR, PRINTER_STATUS_UPDATE_REQUIRED
-    global CHAMBER_LIGHT_IS_ON
+    global PRINTER_STATUS, CHAMBER_LIGHT_IS_ON
 
     try:
         response = api.get_printer_status(config["printer"]["id"])
-        PRINTER_AWAITING_PLATE_CLEAR = response["awaiting_plate_clear"]
-        CHAMBER_LIGHT_IS_ON = response["chamber_light"]
+        PRINTER_AWAITING_PLATE_CLEAR = response.get("awaiting_plate_clear", False)
+        CHAMBER_LIGHT_IS_ON = response.get("chamber_light", True)
+        PRINTER_STATUS = response.get("state", printer_status.PrinterStatus.IDLE)
 
-        print("Printer awaiting plate clear:", PRINTER_AWAITING_PLATE_CLEAR, "Chamber light is on:", CHAMBER_LIGHT_IS_ON)
+        print("Printer status:", PRINTER_STATUS, "Awaiting plate clear:", PRINTER_AWAITING_PLATE_CLEAR, "Chamber light is on:", CHAMBER_LIGHT_IS_ON)
+
+        if PRINTER_STATUS == printer_status.PrinterStatus.PAUSE:
+            flasher.set_interval(500)
+        elif PRINTER_AWAITING_PLATE_CLEAR:
+            flasher.set_interval(config["led"]["flash_interval_ms"])
 
     except Exception as exc:
         print("Failed to fetch printer status:", exc)

--- a/micro/printer_status.py
+++ b/micro/printer_status.py
@@ -1,0 +1,5 @@
+class PrinterStatus:
+    RUNNING = 'RUNNING'
+    PAUSE = 'PAUSE'
+    FINISHED = 'FINISHED'
+    IDLE = 'IDLE'


### PR DESCRIPTION
Adds a secondary button function to resume the next queued print that has been pushed to the printer.

The slower flashing indicates the PAUSE state.

My workflow does not have Clear Plate, but Queued jobs are sent to the printer in a Paused state.

Having the bambutton RESUME would be amazing.

Totally understand if this is not accepted, I have the functionality on my fork.

Fixes #7 