### PR TITLE
On-device setup portal, multi-printer stations, and OTA updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,37 @@ Manual setup requires:
 - A data-capable USB cable.
 - Knowing the serial port if `mpremote` cannot auto-detect the board.
 
+### On-Device Setup Portal (no PC app required)
+
+As an alternative to the desktop assistant, a board can be configured entirely from a phone or browser once the MicroPython firmware and app files are on it.
+
+On first boot — or whenever no Wi-Fi is stored, or the button is held down at power-on — the board starts its own access point **Bambutton-Setup** (default password `bambutton`) and serves a captive setup page:
+
+1. Connect a phone to **Bambutton-Setup**.
+2. Choose your Wi-Fi network, enter the password, and save. The board joins your network and reboots.
+3. The same page is then reachable in a browser at the board's LAN IP (`http://<board-ip>/`), where you enter the Bambuddy address and API key, test the connection, and assign a printer to each button.
+
+Wi-Fi and Bambuddy are configured in separate steps, so you can store Wi-Fi while on a phone/guest network and finish Bambuddy setup later from a PC on the LAN.
+
+## Multiple Printers on One Board
+
+The config describes a list of **stations** — each station is one printer with its own button and LED — so a single ESP32-C3 can drive two (or more) buttons for two printers. One Bambuddy API key works for every station. Default wiring:
+
+```text
+Station A:  LED = GPIO3,  button = GPIO4
+Station B:  LED = GPIO5,  button = GPIO6
+```
+
+In the setup page each button has a **🔦 identify** control that blinks the selected station's LED for a few seconds, so you can tell which physical button you are assigning to which printer.
+
+### Updating over the air (optional)
+
+The setup page can update the app code (the `micro/*.py` files, not the MicroPython firmware itself) without a USB cable: either pull a `manifest.json` plus files from a URL you control, or upload `.py`/`.json` files directly from the browser.
+
+### Backward compatibility
+
+Existing single-printer `config.json` files (the `printer` / `led.pin` / `button.pin` schema written by the desktop assistant) are migrated automatically into the first station when loaded, so boards configured the old way keep working.
+
 ## Layout
 
 ```text
@@ -59,6 +90,10 @@ Key files:
 - `micro/wifi.py` - Wi-Fi connection helper.
 - `micro/gpio_button.py` - debounced GPIO interrupt button helper.
 - `micro/led_flasher.py` - timer-driven LED flasher.
+- `micro/runner.py` - normal-mode loop: multi-station polling, LED logic, and the LAN config server.
+- `micro/webconfig.py` - on-device setup/config web portal (AP captive page + LAN page), OTA update, identify.
+- `micro/provisioning.py` - setup-mode entry point that starts the AP portal.
+- `micro/bb_util.py` - shared helpers (base-URL normalising, printer-name matching).
 - `firmware/ESP32_GENERIC_C3-20260406-v1.28.0.bin` - bundled ESP32-C3 MicroPython firmware image.
 - `scripts/push_micro.py` - copies required MicroPython files to the board with `mpremote`.
 - `scripts/run_main.py` - runs `micro/main.py` on the board without copying it as an auto-start file.
@@ -117,7 +152,7 @@ The macOS app is written to `dist/Bambutton.app`. The Windows executable is writ
 
 ## Manual Configuration
 
-Manual users can edit `micro/config.json` before copying the files to the board:
+Most users never touch `config.json` — the on-device setup portal writes it. Manual users can still edit `micro/config.json` before copying the files to the board. See `micro/config_example.json` for the full schema:
 
 ```json
 {
@@ -131,22 +166,30 @@ Manual users can edit `micro/config.json` before copying the files to the board:
     "key": "your-api-key",
     "request_timeout_seconds": 3
   },
-  "printer": {
-    "id": 3,
-    "poll_interval_seconds": 5
-  },
+  "poll_interval_seconds": 3,
   "led": {
-    "pin": 3,
     "flash_interval_ms": 250
   },
   "button": {
-    "pin": 4,
     "debounce_ms": 150,
     "pull": "down",
     "trigger": "rising"
-  }
+  },
+  "ap": {
+    "ssid": "Bambutton-Setup",
+    "password": "bambutton"
+  },
+  "update": {
+    "url": ""
+  },
+  "stations": [
+    {"printer_id": "PRINTER NAME OR NUMERIC ID", "led_pin": 3, "button_pin": 4},
+    {"printer_id": "", "led_pin": 5, "button_pin": 6}
+  ]
 }
 ```
+
+`printer_id` accepts either the printer's Bambuddy friendly name (case-insensitive, partial match allowed) or its numeric id. Leave a station's `printer_id` empty to disable it. Older single-printer configs using the `printer` / `led.pin` / `button.pin` keys are migrated automatically. The optional top-level `hostname` (default `bambutton`) is announced to the router so the board is easy to find in the client list.
 
 ## Manual Copying
 

--- a/micro/bb_util.py
+++ b/micro/bb_util.py
@@ -1,0 +1,67 @@
+"""Shared helpers used by the runner (normal mode) and the setup portal."""
+
+
+def normalize_base_url(raw):
+    url = str(raw).strip()
+    if not url:
+        return url
+    if not (url.startswith("http://") or url.startswith("https://")):
+        url = "http://" + url
+    url = url.rstrip("/")
+    if not url.endswith("/api/v1"):
+        url = url + "/api/v1"
+    return url
+
+
+def extract_list(payload):
+    if isinstance(payload, dict):
+        for key in ("printers", "results", "items"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+    if isinstance(payload, list):
+        return payload
+    return []
+
+
+def printer_label(printer):
+    return str(
+        printer.get("friendly_name")
+        or printer.get("name")
+        or printer.get("display_name")
+        or ("ID %s" % printer.get("id"))
+    )
+
+
+def build_name_map(printers):
+    name_map = {}
+    for printer in printers:
+        if not isinstance(printer, dict) or "id" not in printer:
+            continue
+        for field in ("friendly_name", "name", "display_name"):
+            value = printer.get(field)
+            if value:
+                name_map[str(value).strip().lower()] = printer["id"]
+    return name_map
+
+
+def is_numeric(ref):
+    return isinstance(ref, int) or (isinstance(ref, str) and ref.strip().isdigit())
+
+
+def match_printer_id(ref, name_map):
+    """Numeric id used directly; a name resolved exact-then-contains."""
+    if isinstance(ref, int):
+        return ref
+    text = str(ref).strip()
+    if text == "":
+        return None
+    if text.isdigit():
+        return int(text)
+    key = text.lower()
+    if key in name_map:
+        return name_map[key]
+    matches = [pid for name, pid in name_map.items() if key in name]
+    if len(matches) == 1:
+        return matches[0]
+    return None

--- a/micro/config_example.json
+++ b/micro/config_example.json
@@ -4,23 +4,30 @@
     "password": "YOUR WIFI PASSWORD",
     "timeout_seconds": 10
   },
+  "hostname": "bambutton",
   "api": {
     "base_url": "http://<BAMBUDDY_IP>:<BAMBUDDY_PORT>/api/v1",
     "key": "YOUR API KEY",
     "request_timeout_seconds": 3
   },
-  "printer": {
-    "id": 1,
-    "poll_interval_seconds": 3
-  },
+  "poll_interval_seconds": 3,
   "led": {
-    "pin": 3,
     "flash_interval_ms": 250
   },
   "button": {
-    "pin": 4,
     "debounce_ms": 150,
     "pull": "down",
     "trigger": "rising"
-  }
+  },
+  "ap": {
+    "ssid": "Bambutton-Setup",
+    "password": "bambutton"
+  },
+  "update": {
+    "url": ""
+  },
+  "stations": [
+    {"printer_id": "PRINTER NAME OR NUMERIC ID", "led_pin": 3, "button_pin": 4},
+    {"printer_id": "", "led_pin": 5, "button_pin": 6}
+  ]
 }

--- a/micro/config_loader.py
+++ b/micro/config_loader.py
@@ -4,58 +4,109 @@ except ImportError:
     import json
 
 
+# Multi-station schema. Wi-Fi/API are shared; each station is one printer with
+# its own button + LED. A fresh flash ships this stub (no secrets, no printer
+# assigned) so the board boots straight into the setup portal.
 DEFAULT_CONFIG = {
     "wifi": {
         "ssid": "",
         "password": "",
         "timeout_seconds": 10,
     },
+    "hostname": "bambutton",
     "api": {
         "base_url": "",
         "key": "",
         "request_timeout_seconds": 3,
     },
-    "printer": {
-        "id": 3,
-        "poll_interval_seconds": 5,
-    },
+    "poll_interval_seconds": 3,
     "led": {
-        "pin": 3,
         "flash_interval_ms": 250,
     },
     "button": {
-        "pin": 4,
         "debounce_ms": 150,
         "pull": "down",
         "trigger": "rising",
     },
+    "ap": {
+        "ssid": "Bambutton-Setup",
+        "password": "bambutton",
+    },
+    "update": {
+        "url": "",
+    },
+    "stations": [
+        {"printer_id": "", "led_pin": 3, "button_pin": 4},
+        {"printer_id": "", "led_pin": 5, "button_pin": 6},
+    ],
 }
 
 
 def load_config(path="config.json"):
-    config = _copy_dict(DEFAULT_CONFIG)
-
+    config = _copy_value(DEFAULT_CONFIG)
     try:
         with open(path) as config_file:
-            loaded_config = json.load(config_file)
+            loaded = json.load(config_file)
     except OSError:
         print("Config file not found, using defaults:", path)
         return config
-
-    _deep_update(config, loaded_config)
+    _deep_update(config, loaded)
+    _migrate_legacy(config)
     return config
 
 
-def _copy_dict(source):
-    result = {}
+def save_config(config, path="config.json"):
+    with open(path, "w") as config_file:
+        config_file.write(json.dumps(config))
 
-    for key, value in source.items():
-        if isinstance(value, dict):
-            result[key] = _copy_dict(value)
-        else:
-            result[key] = value
 
-    return result
+def config_complete(config):
+    """True when the board has enough to run normally (skip the setup portal)."""
+    wifi = config.get("wifi", {})
+    api = config.get("api", {})
+    if not str(wifi.get("ssid", "")).strip():
+        return False
+    if not str(api.get("base_url", "")).strip():
+        return False
+    if not str(api.get("key", "")).strip():
+        return False
+    for station in config.get("stations", []):
+        if str(station.get("printer_id", "")).strip():
+            return True  # at least one station has a printer assigned
+    return False
+
+
+def _migrate_legacy(config):
+    """Fold an old single-printer config (printer{}/led.pin/button.pin, as the
+    desktop setup assistant still writes) into station 0 so existing setups keep
+    working after the multi-station schema change."""
+    legacy_id = str(config.get("printer", {}).get("id", "")).strip()
+    if not legacy_id:
+        return
+    stations = config.get("stations") or []
+    if any(str(s.get("printer_id", "")).strip() for s in stations):
+        return  # already migrated / explicitly configured
+    if not stations:
+        stations = [{"printer_id": "", "led_pin": 3, "button_pin": 4}]
+        config["stations"] = stations
+    stations[0]["printer_id"] = legacy_id
+    led_pin = config.get("led", {}).get("pin")
+    if led_pin is not None:
+        stations[0]["led_pin"] = led_pin
+    button_pin = config.get("button", {}).get("pin")
+    if button_pin is not None:
+        stations[0]["button_pin"] = button_pin
+    poll = config.get("printer", {}).get("poll_interval_seconds")
+    if poll is not None:
+        config["poll_interval_seconds"] = poll
+
+
+def _copy_value(value):
+    if isinstance(value, dict):
+        return {key: _copy_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_copy_value(item) for item in value]
+    return value
 
 
 def _deep_update(target, source):
@@ -63,4 +114,4 @@ def _deep_update(target, source):
         if isinstance(value, dict) and isinstance(target.get(key), dict):
             _deep_update(target[key], value)
         else:
-            target[key] = value
+            target[key] = _copy_value(value)

--- a/micro/main.py
+++ b/micro/main.py
@@ -1,146 +1,85 @@
+"""Boot orchestrator.
+
+- Config button held at power-on  -> setup portal
+- Config incomplete (fresh flash) -> setup portal
+- Otherwise run normally; if Wi-Fi won't come up -> fall back to setup portal
+"""
 import time
-from machine import WDT
-import bambuddy_api
-import config_loader
-import gpio_button
-import led_flasher
-import wifi
-import periodic_timer
 
-
-config = config_loader.load_config()
-
-# -- Runtime Flags ---
-PRINTER_AWAITING_PLATE_CLEAR = False
-PENDING_BUTTON_PRESS = False
-CHAMBER_LIGHT_IS_ON = True
-PRINTER_STATUS_UPDATE_REQUIRED = True
-
-# Feed this only from the healthy main loop. If a network request or the
-# networking stack blocks, the board will reboot and reconnect from scratch.
-watchdog = WDT(timeout=60_000)
-
-# -- Initialize LED flasher ---
-flasher = led_flasher.LedFlasher(
-    pin_number=config["led"]["pin"],
-    should_flash=lambda: (
-        PRINTER_AWAITING_PLATE_CLEAR and not PENDING_BUTTON_PRESS
-    ),
-    interval_ms=config["led"]["flash_interval_ms"],
-    inactive_value=lambda: CHAMBER_LIGHT_IS_ON,
-)
-flasher.start()
-
-
-# -- Button handler ---
-def IRQ_button_press(pin):
-    global PENDING_BUTTON_PRESS
-    global PRINTER_AWAITING_PLATE_CLEAR
-
-    # This runs in the hardware interrupt. Keep it allocation-free so the LED
-    # stops flashing even while a status request is still timing out.
-    if PRINTER_AWAITING_PLATE_CLEAR:
-        PRINTER_AWAITING_PLATE_CLEAR = False
-        PENDING_BUTTON_PRESS = True
-
-
-button = gpio_button.GPIOButton(
-    pin_number=config["button"]["pin"],
-    on_press=IRQ_button_press,
-    debounce_ms=config["button"]["debounce_ms"],
-    pull=config["button"]["pull"],
-    trigger=config["button"]["trigger"],
-)
-button.start()
-
-
-# -- Connect to Wi-Fi --
 try:
-    network = wifi.WiFi(
-        ssid=config["wifi"]["ssid"],
-        password=config["wifi"]["password"],
-        status_led=None,
-        timeout_seconds=config["wifi"]["timeout_seconds"],
-    )
-    network.connect()
+    from machine import Pin
+except ImportError:  # host-side testing
+    Pin = None
 
-except Exception as exc:
-    print("Wi-Fi connection failed:", exc)
-    flasher.on()
-    raise
-
-# -- Initialize API client --
-api = bambuddy_api.BambuddyAPI(
-    config["api"]["key"],
-    config["api"]["base_url"],
-    config["api"]["request_timeout_seconds"],
-)
+import config_loader
 
 
-# --- Setup Polling Loop ---
-def IRQ_printer_update_tick():
-    global PRINTER_STATUS_UPDATE_REQUIRED
-    PRINTER_STATUS_UPDATE_REQUIRED = True
-
-
-poll_timer = periodic_timer.PeriodicTimer(
-    period_ms=config["printer"]["poll_interval_seconds"] * 1000,
-    callback=IRQ_printer_update_tick,
-)
-poll_timer.start()
-
-
-# --- Main loop handlers ---
-def with_network_connection(request):
-    network.ensure_connected()
-    return request()
-
-
-def handle_pending_button_press():
-    global PENDING_BUTTON_PRESS
-    global PRINTER_STATUS_UPDATE_REQUIRED
-
+def config_button_pressed(config):
+    """True if station A's button is held down at boot (pull-down: pressed=HIGH)."""
+    if Pin is None:
+        return False
     try:
-        with_network_connection(
-            lambda: api.clear_plate(config["printer"]["id"])
-        )
-        PRINTER_STATUS_UPDATE_REQUIRED = True
-
-    except Exception as exc:
-        print("Failed to send plate clear request:", exc)
-
-    PENDING_BUTTON_PRESS = False
-
-
-def handle_printer_status_update():
-    global PRINTER_AWAITING_PLATE_CLEAR, PRINTER_STATUS_UPDATE_REQUIRED
-    global CHAMBER_LIGHT_IS_ON
-
+        stations = config.get("stations") or []
+        pin_no = stations[0].get("button_pin", 4) if stations else 4
+    except Exception:
+        pin_no = 4
     try:
-        response = with_network_connection(
-            lambda: api.get_printer_status(config["printer"]["id"])
-        )
-        PRINTER_AWAITING_PLATE_CLEAR = response["awaiting_plate_clear"]
-        CHAMBER_LIGHT_IS_ON = response["chamber_light"]
+        pin = Pin(pin_no, Pin.IN, Pin.PULL_DOWN)
+        high = 0
+        for _ in range(6):
+            if pin.value():
+                high += 1
+            if hasattr(time, "sleep_ms"):
+                time.sleep_ms(15)
+            else:
+                time.sleep(0.015)
+        return high >= 5
+    except Exception:
+        return False
 
-        print("Printer awaiting plate clear:", PRINTER_AWAITING_PLATE_CLEAR, "Chamber light is on:", CHAMBER_LIGHT_IS_ON)
 
+def apply_hostname(config):
+    """Set the network/DHCP hostname before Wi-Fi comes up, so the board shows
+    up by name in the router/client list instead of a generic chip name."""
+    name = str(config.get("hostname", "")).strip()
+    if not name:
+        return
+    try:
+        import network
+        network.hostname(name)
+        print("Hostname:", name)
     except Exception as exc:
-        print("Failed to fetch printer status:", exc)
-
-    PRINTER_STATUS_UPDATE_REQUIRED = False
+        print("hostname set failed:", exc)
 
 
-# -- Main loop --
-while True:
-    watchdog.feed()
+def decide_setup(config, button_pressed):
+    # Only the Wi-Fi credentials gate the setup AP. Bambuddy + printers are set
+    # afterwards from a PC via the board's LAN IP.
+    if button_pressed:
+        return True, "Config-Taste beim Start gehalten"
+    if not str(config.get("wifi", {}).get("ssid", "")).strip():
+        return True, "Kein WLAN hinterlegt"
+    return False, ""
 
-    # Push button press to API if pending
-    if PENDING_BUTTON_PRESS:
-        handle_pending_button_press()
 
-    # Check printer status
-    if PRINTER_STATUS_UPDATE_REQUIRED:
-        handle_printer_status_update()
+def main():
+    config = config_loader.load_config()
+    apply_hostname(config)
+    setup, reason = decide_setup(config, config_button_pressed(config))
+    if setup:
+        print("Setup-Modus:", reason)
+        import provisioning
+        provisioning.run(config)
+        return
 
-    time.sleep_ms(25)
+    import runner
+    try:
+        runner.run(config)
+    except Exception as exc:
+        print("Normalbetrieb nicht moeglich -> Setup-Modus:", exc)
+        import provisioning
+        provisioning.run(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/micro/provisioning.py
+++ b/micro/provisioning.py
@@ -1,0 +1,7 @@
+"""Setup mode entry point: opens the access point + captive portal.
+The actual web layer lives in webconfig (shared with normal mode)."""
+import webconfig
+
+
+def run(config):
+    webconfig.run_setup(config)

--- a/micro/runner.py
+++ b/micro/runner.py
@@ -1,0 +1,275 @@
+"""Normal operating mode: join Wi-Fi, serve the config page at the board's LAN
+IP (so Bambuddy/printers can be set from a PC), and poll whatever stations are
+configured. Started by main.py once Wi-Fi credentials exist.
+
+All wired stations are created (even without a printer assigned) so their LED
+can be blinked from the web UI ("identify"); unassigned stations stay dark and
+are not polled. The board is reachable on the LAN even before Bambuddy is set."""
+import time
+
+try:
+    from machine import Pin, WDT
+except ImportError:  # allows host-side testing
+    Pin = None
+    WDT = None
+try:
+    from machine import reset as machine_reset
+except ImportError:
+    machine_reset = None
+
+import bambuddy_api
+import gpio_button
+import wifi
+import periodic_timer
+import bb_util
+import webconfig
+
+
+def _now_ms():
+    return time.ticks_ms() if hasattr(time, "ticks_ms") else int(time.time() * 1000)
+
+
+def _diff_ms(a, b):
+    return time.ticks_diff(a, b) if hasattr(time, "ticks_diff") else (a - b)
+
+
+class Station:
+    def __init__(self, index, printer_ref, led_pin, button_pin,
+                 debounce_ms=150, pull="down", trigger="rising"):
+        self.index = index
+        self.printer_ref = printer_ref
+        self.active = bool(str(printer_ref).strip())
+        self.printer_id = None
+        self.led = Pin(led_pin, Pin.OUT)
+        self.awaiting_plate_clear = False
+        self.pending_button_press = False
+        self.chamber_light_on = True
+        self.status_update_required = True
+        self.identify_until = 0
+        self.button = gpio_button.GPIOButton(
+            pin_number=button_pin,
+            on_press=self._on_press,
+            debounce_ms=debounce_ms,
+            pull=pull,
+            trigger=trigger,
+        )
+
+    def _on_press(self, pin):
+        if self.awaiting_plate_clear:
+            self.awaiting_plate_clear = False
+            self.pending_button_press = True
+
+    def start_button(self):
+        self.button.start()
+
+    def identify(self, seconds=4):
+        self.identify_until = _now_ms() + int(float(seconds) * 1000)
+
+    def update_led(self):
+        if self.identify_until and _diff_ms(self.identify_until, _now_ms()) > 0:
+            self.led.value(0 if self.led.value() else 1)   # blink to identify
+            return
+        if not self.active:
+            self.led.value(0)                                # no printer -> dark
+            return
+        if self.awaiting_plate_clear and not self.pending_button_press:
+            self.led.value(0 if self.led.value() else 1)
+        else:
+            self.led.value(1 if self.chamber_light_on else 0)
+
+
+def build_stations(config):
+    button_cfg = config.get("button", {})
+    stations = []
+    for index, entry in enumerate(config.get("stations", [])):
+        stations.append(
+            Station(
+                index=index,
+                printer_ref=entry.get("printer_id", entry.get("printer", "")),
+                led_pin=entry["led_pin"],
+                button_pin=entry["button_pin"],
+                debounce_ms=button_cfg.get("debounce_ms", 150),
+                pull=button_cfg.get("pull", "down"),
+                trigger=button_cfg.get("trigger", "rising"),
+            )
+        )
+    return stations
+
+
+def network_call(network, request):
+    network.ensure_connected()
+    return request()
+
+
+def resolve_station_ids(api, network, stations):
+    name_map = {}
+    need_names = False
+    for station in stations:
+        if station.printer_id is None and not bb_util.is_numeric(station.printer_ref):
+            need_names = True
+            break
+    if need_names:
+        try:
+            printers = network_call(network, lambda: api.get_printers())
+            name_map = bb_util.build_name_map(bb_util.extract_list(printers))
+            print("Bambuddy printers:", list(name_map.keys()))
+        except Exception as exc:
+            print("Could not fetch printer list:", exc)
+            return False
+
+    all_resolved = True
+    for station in stations:
+        if station.printer_id is not None:
+            continue
+        pid = bb_util.match_printer_id(station.printer_ref, name_map)
+        if pid is None:
+            all_resolved = False
+            print("Station", station.index, "could not resolve printer:", station.printer_ref)
+        else:
+            station.printer_id = pid
+            print("Station", station.index, "->", station.printer_ref, "= id", pid)
+    return all_resolved
+
+
+def handle_pending_press(api, network, station):
+    try:
+        network_call(network, lambda: api.clear_plate(station.printer_id))
+        station.status_update_required = True
+        print("Station", station.index, "plate marked clear")
+    except Exception as exc:
+        print("Station", station.index, "clear-plate failed:", exc)
+    station.pending_button_press = False
+
+
+def handle_status_update(api, network, station):
+    if station.printer_id is None:
+        station.status_update_required = False
+        return
+    try:
+        response = network_call(network, lambda: api.get_printer_status(station.printer_id))
+        station.awaiting_plate_clear = bool(response.get("awaiting_plate_clear", False))
+        station.chamber_light_on = bool(response.get("chamber_light", station.chamber_light_on))
+    except Exception as exc:
+        print("Station", station.index, "status fetch failed:", exc)
+    station.status_update_required = False
+
+
+def _sleep_ms(ms):
+    if hasattr(time, "sleep_ms"):
+        time.sleep_ms(ms)
+    else:
+        time.sleep(ms / 1000.0)
+
+
+def connect_wifi(config, stations, attempts=3):
+    network = wifi.WiFi(
+        ssid=config["wifi"]["ssid"],
+        password=config["wifi"]["password"],
+        status_led=None,
+        timeout_seconds=config["wifi"].get("timeout_seconds", 10),
+    )
+    last = None
+    for _ in range(attempts):
+        try:
+            network.connect()
+            return network
+        except Exception as exc:
+            last = exc
+            print("Wi-Fi attempt failed:", exc)
+            time.sleep(1)
+    for station in stations:
+        station.led.value(1)
+    raise RuntimeError("Wi-Fi connect failed: %s" % last)
+
+
+def build_api(config):
+    api_cfg = config.get("api", {})
+    base = str(api_cfg.get("base_url", "")).strip()
+    key = str(api_cfg.get("key", "")).strip()
+    if not base or not key:
+        return None
+    return bambuddy_api.BambuddyAPI(
+        key, bb_util.normalize_base_url(base), api_cfg.get("request_timeout_seconds", 3)
+    )
+
+
+def run(config, max_iterations=None):
+    stations = build_stations(config)               # all wired stations
+    active = [s for s in stations if s.active]       # those with a printer
+
+    watchdog = WDT(timeout=60_000) if WDT else None
+    for station in stations:
+        station.start_button()
+
+    network = connect_wifi(config, stations)         # raises on failure -> setup
+    api = build_api(config)                           # None until Bambuddy set
+
+    if api and active:
+        attempts = 0
+        while not resolve_station_ids(api, network, active):
+            if watchdog:
+                watchdog.feed()
+            attempts += 1
+            if attempts >= 3:
+                print("Continuing; unresolved stations will keep retrying.")
+                break
+            time.sleep(3)
+
+    poll_state = {"due": True}
+
+    def on_poll_tick():
+        poll_state["due"] = True
+
+    def on_flash_tick():
+        for station in stations:
+            station.update_led()
+
+    if stations:
+        periodic_timer.PeriodicTimer(
+            period_ms=int(config.get("poll_interval_seconds", 3) * 1000),
+            callback=on_poll_tick,
+        ).start()
+        periodic_timer.PeriodicTimer(
+            period_ms=int(config.get("led", {}).get("flash_interval_ms", 250)),
+            callback=on_flash_tick,
+        ).start()
+
+    webconfig.FEED = watchdog.feed if watchdog else None
+    server = None
+    if max_iterations is None:
+        try:
+            server = webconfig.Server(config, {"mode": "normal", "api": api, "stations": stations})
+            print("Konfig-Server: http://%s/" % network.ifconfig()[0])
+        except Exception as exc:
+            print("Konfig-Server nicht gestartet:", exc)
+
+    iterations = 0
+    while True:
+        if watchdog:
+            watchdog.feed()
+
+        if api and active:
+            for station in active:
+                if station.pending_button_press:
+                    handle_pending_press(api, network, station)
+            if poll_state["due"]:
+                poll_state["due"] = False
+                for station in active:
+                    if station.printer_id is None:
+                        resolve_station_ids(api, network, [station])
+                    handle_status_update(api, network, station)
+
+        if server is not None:
+            try:
+                if server.poll():
+                    print("Konfig gespeichert/aktualisiert -> Neustart")
+                    _sleep_ms(300)
+                    if machine_reset:
+                        machine_reset()
+            except Exception as exc:
+                print("Konfig-Server-Fehler:", exc)
+
+        iterations += 1
+        if max_iterations is not None and iterations >= max_iterations:
+            return stations
+        _sleep_ms(25)

--- a/micro/webconfig.py
+++ b/micro/webconfig.py
@@ -1,0 +1,731 @@
+"""Shared web layer used by both modes:
+
+- Setup mode (AP): full portal (Wi-Fi scan + test + assign printers) via run_setup().
+- Normal mode (STA): the same page under the board's LAN IP via Server(), so you
+  can re-assign printers or change settings anytime, plus OTA app-code updates
+  (browser upload or GitHub pull).
+
+route()/parse/handlers are plain functions so they can be tested off-device.
+"""
+import time
+
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+try:
+    import network
+except ImportError:
+    network = None
+try:
+    import machine
+except ImportError:
+    machine = None
+try:
+    import urequests
+except ImportError:
+    urequests = None
+
+import bambuddy_api
+import config_loader
+import bb_util
+
+
+VERSION = "2.3.0"
+AP_IP = "192.168.4.1"
+ALLOWED_UPLOAD_SUFFIX = (".py", ".json")
+
+FEED = None  # optional watchdog-feed callback, set by the runner during OTA
+
+
+def _feed():
+    if FEED:
+        try:
+            FEED()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------- HTTP parsing
+
+def parse_request(head_bytes):
+    try:
+        text = head_bytes.decode("utf-8", "replace")
+    except Exception:
+        return None
+    lines = text.split("\r\n")
+    if not lines or " " not in lines[0]:
+        return None
+    parts = lines[0].split(" ")
+    if len(parts) < 2:
+        return None
+    headers = {}
+    for line in lines[1:]:
+        if ":" in line:
+            k, v = line.split(":", 1)
+            headers[k.strip().lower()] = v.strip()
+    return parts[0], parts[1], headers
+
+
+def json_body(body_bytes):
+    try:
+        return json.loads(body_bytes.decode("utf-8"))
+    except Exception:
+        return {}
+
+
+def ip_port_from_base_url(base_url):
+    s = str(base_url or "")
+    s = s.replace("https://", "").replace("http://", "")
+    s = s.replace("/api/v1", "")
+    return s.strip("/")
+
+
+# ------------------------------------------------------------------ Wi-Fi ops
+
+def _sta():
+    return network.WLAN(network.STA_IF)
+
+
+def do_scan():
+    sta = _sta()
+    sta.active(True)
+    try:
+        nets = sta.scan()
+    except Exception as exc:
+        return {"networks": [], "error": str(exc)}
+    best = {}
+    for n in nets:
+        try:
+            ssid = n[0].decode("utf-8", "replace")
+        except Exception:
+            ssid = str(n[0])
+        if not ssid:
+            continue
+        if ssid not in best or n[3] > best[ssid][0]:
+            best[ssid] = (n[3], n[2])
+    out = [{"ssid": s, "rssi": best[s][0], "ch": best[s][1]}
+           for s in sorted(best, key=lambda s: best[s][0], reverse=True)]
+    return {"networks": out}
+
+
+def sta_connect(ssid, password, timeout=15):
+    sta = _sta()
+    sta.active(True)
+    if sta.isconnected():
+        try:
+            sta.disconnect()
+        except Exception:
+            pass
+        time.sleep(0.3)
+    sta.connect(ssid, password)
+    ticks = time.ticks_ms if hasattr(time, "ticks_ms") else (lambda: int(time.time() * 1000))
+    diff = time.ticks_diff if hasattr(time, "ticks_diff") else (lambda a, b: a - b)
+    t0 = ticks()
+    while not sta.isconnected():
+        if diff(ticks(), t0) > timeout * 1000:
+            return False
+        time.sleep(0.25)
+    return True
+
+
+def _api_from_config(config):
+    return bambuddy_api.BambuddyAPI(
+        config["api"]["key"],
+        bb_util.normalize_base_url(config["api"]["base_url"]),
+        config["api"].get("request_timeout_seconds", 5),
+    )
+
+
+def _printers_payload(api):
+    out = []
+    for p in bb_util.extract_list(api.get_printers()):
+        if isinstance(p, dict) and "id" in p:
+            out.append({"id": p["id"], "label": bb_util.printer_label(p)})
+    return out
+
+
+def do_test(params):
+    ssid = str(params.get("ssid", "")).strip()
+    password = str(params.get("password", ""))
+    host = str(params.get("host", "")).strip()
+    key = str(params.get("key", "")).strip()
+    if not ssid or not host or not key:
+        return {"ok": False, "error": "SSID, Bambuddy-Adresse und API-Key noetig."}
+    if not sta_connect(ssid, password):
+        return {"ok": False, "error": "WLAN-Verbindung fehlgeschlagen (SSID/Passwort pruefen)."}
+    api = bambuddy_api.BambuddyAPI(key, bb_util.normalize_base_url(host), 6)
+    try:
+        return {"ok": True, "printers": _printers_payload(api)}
+    except Exception as exc:
+        return {"ok": False, "error": "Bambuddy nicht erreichbar / Key falsch: %s" % exc}
+
+
+def do_printers(config, ctx):
+    api = ctx.get("api") if ctx else None
+    if api is None:
+        api = _api_from_config(config)
+    try:
+        return {"ok": True, "printers": _printers_payload(api)}
+    except Exception as exc:
+        return {"ok": False, "error": "Druckerliste nicht abrufbar: %s" % exc}
+
+
+def do_wifitest(params):
+    ssid = str(params.get("ssid", "")).strip()
+    password = str(params.get("password", ""))
+    if not ssid:
+        return {"ok": False, "error": "Bitte WLAN waehlen."}
+    if not sta_connect(ssid, password):
+        return {"ok": False, "error": "WLAN-Verbindung fehlgeschlagen (Passwort pruefen)."}
+    ip = ""
+    try:
+        ip = _sta().ifconfig()[0]
+    except Exception:
+        ip = ""
+    return {"ok": True, "ip": ip}
+
+
+def do_probe(params, config):
+    host = str(params.get("host", "")).strip()
+    base = host if host else str(config.get("api", {}).get("base_url", "")).strip()
+    key = str(params.get("key", "")).strip() or str(config.get("api", {}).get("key", "")).strip()
+    if not base or not key:
+        return {"ok": False, "error": "Bambuddy-Adresse und API-Key eingeben."}
+    api = bambuddy_api.BambuddyAPI(key, bb_util.normalize_base_url(base), 6)
+    try:
+        return {"ok": True, "printers": _printers_payload(api)}
+    except Exception as exc:
+        return {"ok": False, "error": "Bambuddy nicht erreichbar / Key falsch: %s" % exc}
+
+
+def _keep(new, old):
+    new = "" if new is None else str(new)
+    return new if new.strip() != "" else old
+
+
+def do_save(params, config, state):
+    wifi = config.setdefault("wifi", {})
+    api = config.setdefault("api", {})
+    wifi["ssid"] = _keep(params.get("ssid"), wifi.get("ssid", ""))
+    wifi["password"] = _keep(params.get("password"), wifi.get("password", ""))
+    host = params.get("host")
+    if host is not None and str(host).strip() != "":
+        api["base_url"] = bb_util.normalize_base_url(str(host).strip())
+    api["key"] = _keep(params.get("key"), api.get("key", ""))
+    if "update_url" in params:
+        config.setdefault("update", {})["url"] = str(params.get("update_url", "")).strip()
+
+    by_index = {}
+    for a in params.get("stations", []):
+        try:
+            by_index[int(a.get("index"))] = a.get("printer_id", "")
+        except Exception:
+            pass
+    for i, st in enumerate(config.get("stations", [])):
+        if i in by_index:
+            st["printer_id"] = by_index[i]
+
+    try:
+        config_loader.save_config(config)
+    except Exception as exc:
+        return {"ok": False, "error": "Speichern fehlgeschlagen: %s" % exc}
+    state["reset"] = True
+    return {"ok": True}
+
+
+def _safe_name(filename):
+    fn = str(filename or "").strip()
+    if not fn or "/" in fn or "\\" in fn or ".." in fn:
+        return None
+    if not fn.endswith(ALLOWED_UPLOAD_SUFFIX):
+        return None
+    return fn
+
+
+def do_upload(params):
+    fn = _safe_name(params.get("filename"))
+    if fn is None:
+        return {"ok": False, "error": "Ungueltiger Dateiname (nur .py/.json, kein Pfad)."}
+    content = params.get("content")
+    if not isinstance(content, str):
+        return {"ok": False, "error": "Kein Textinhalt."}
+    try:
+        with open(fn, "w") as f:
+            f.write(content)
+    except Exception as exc:
+        return {"ok": False, "error": "Schreiben fehlgeschlagen: %s" % exc}
+    return {"ok": True, "file": fn, "bytes": len(content)}
+
+
+def _http_get_text(url, timeout=10):
+    resp = urequests.get(url, timeout=timeout) if urequests else None
+    if resp is None:
+        raise RuntimeError("kein HTTP-Client")
+    try:
+        code = getattr(resp, "status_code", 200)
+        text = resp.text
+    finally:
+        try:
+            resp.close()
+        except Exception:
+            pass
+    if code < 200 or code >= 300:
+        raise RuntimeError("HTTP %s fuer %s" % (code, url))
+    return text
+
+
+def do_update(params, config, state):
+    url = str(params.get("url", "")).strip() or config.get("update", {}).get("url", "")
+    url = url.rstrip("/")
+    if not url:
+        return {"ok": False, "error": "Keine Update-URL gesetzt."}
+    config.setdefault("update", {})["url"] = url
+    try:
+        manifest = json.loads(_http_get_text(url + "/manifest.json"))
+    except Exception as exc:
+        return {"ok": False, "error": "Manifest nicht ladbar: %s" % exc}
+    files = manifest.get("files") if isinstance(manifest, dict) else None
+    if not isinstance(files, list) or not files:
+        return {"ok": False, "error": "Manifest ohne Dateiliste."}
+    written = []
+    for name in files:
+        _feed()
+        fn = _safe_name(name)
+        if fn is None:
+            return {"ok": False, "error": "Manifest enthaelt unsicheren Namen: %s" % name}
+        try:
+            text = _http_get_text(url + "/" + fn)
+        except Exception as exc:
+            return {"ok": False, "error": "Datei %s nicht ladbar: %s" % (fn, exc)}
+        try:
+            with open(fn, "w") as f:
+                f.write(text)
+        except Exception as exc:
+            return {"ok": False, "error": "Schreiben %s fehlgeschlagen: %s" % (fn, exc)}
+        written.append(fn)
+    try:
+        config_loader.save_config(config)
+    except Exception:
+        pass
+    state["reset"] = True
+    return {"ok": True, "version": manifest.get("version", "?"), "files": written}
+
+
+def do_reboot(state):
+    state["reset"] = True
+    return {"ok": True}
+
+
+def do_identify(params, ctx):
+    """Blink a station's LED so the user can see which physical button it is."""
+    stations = ctx.get("stations") if ctx else None
+    if not stations:
+        return {"ok": False, "error": "Nur im Normalbetrieb verfuegbar."}
+    try:
+        idx = int(params.get("index"))
+    except Exception:
+        return {"ok": False, "error": "index fehlt"}
+    seconds = params.get("seconds", 4)
+    for st in stations:
+        if getattr(st, "index", None) == idx:
+            try:
+                st.identify(seconds)
+            except Exception as exc:
+                return {"ok": False, "error": str(exc)}
+            return {"ok": True}
+    return {"ok": False, "error": "Station %s nicht gefunden" % idx}
+
+
+def do_status(config, ctx):
+    ip = ""
+    try:
+        if network:
+            ip = _sta().ifconfig()[0]
+    except Exception:
+        ip = ""
+    return {"version": VERSION, "mode": ctx.get("mode") if ctx else "?", "ip": ip}
+
+
+# ---------------------------------------------------------------- HTTP routing
+
+def route(method, path, body_bytes, config, state, ctx=None):
+    ctx = ctx or {"mode": "setup"}
+    p = path.split("?", 1)[0]
+    if p == "/scan":
+        return _json(do_scan())
+    if p == "/printers":
+        return _json(do_printers(config, ctx))
+    if p == "/status":
+        return _json(do_status(config, ctx))
+    if p == "/probe" and method == "POST":
+        return _json(do_probe(json_body(body_bytes), config))
+    if p == "/wifitest" and method == "POST":
+        return _json(do_wifitest(json_body(body_bytes)))
+    if p == "/test" and method == "POST":
+        return _json(do_test(json_body(body_bytes)))
+    if p == "/save" and method == "POST":
+        return _json(do_save(json_body(body_bytes), config, state))
+    if p == "/update" and method == "POST":
+        return _json(do_update(json_body(body_bytes), config, state))
+    if p == "/upload" and method == "POST":
+        return _json(do_upload(json_body(body_bytes)))
+    if p == "/reboot" and method == "POST":
+        return _json(do_reboot(state))
+    if p == "/identify" and method == "POST":
+        return _json(do_identify(json_body(body_bytes), ctx))
+    return "200 OK", "text/html; charset=utf-8", render_page(config, ctx.get("mode", "setup"))
+
+
+def _json(obj):
+    return "200 OK", "application/json", json.dumps(obj)
+
+
+def render_page(config, mode):
+    cfg = {
+        "ssid": config.get("wifi", {}).get("ssid", ""),
+        "host": ip_port_from_base_url(config.get("api", {}).get("base_url", "")),
+        "update_url": config.get("update", {}).get("url", ""),
+        "stations": [{"index": i, "printer_id": st.get("printer_id", "")}
+                     for i, st in enumerate(config.get("stations", []))],
+    }
+    inject = "<script>window.MODE=%s;window.VERSION=%s;window.CFG=%s;</script>" % (
+        json.dumps(mode), json.dumps(VERSION), json.dumps(cfg))
+    return PAGE.replace("<!--INJECT-->", inject)
+
+
+# ------------------------------------------------------------------- DNS (A->AP)
+
+def build_dns_response(query, ip):
+    if len(query) < 12:
+        return None
+    tid = query[0:2]
+    counts = query[4:6] + b"\x00\x01" + b"\x00\x00" + b"\x00\x00"
+    idx = 12
+    while idx < len(query) and query[idx] != 0:
+        idx += 1 + query[idx]
+    idx += 1
+    question = query[12:idx + 4]
+    try:
+        ipb = bytes(int(x) for x in ip.split("."))
+    except Exception:
+        return None
+    answer = b"\xc0\x0c\x00\x01\x00\x01\x00\x00\x00\x3c\x00\x04" + ipb
+    return tid + b"\x81\x80" + counts + question + answer
+
+
+# --------------------------------------------------------------- socket helpers
+
+def read_http(conn):
+    conn.settimeout(6)
+    data = b""
+    try:
+        while b"\r\n\r\n" not in data:
+            chunk = conn.recv(512)
+            if not chunk:
+                break
+            data += chunk
+            if len(data) > 65536:
+                break
+    except Exception:
+        pass
+    if not data:
+        return None, None, None, b""
+    head, _, rest = data.partition(b"\r\n\r\n")
+    parsed = parse_request(head)
+    if not parsed:
+        return None, None, None, b""
+    method, path, headers = parsed
+    body = rest
+    try:
+        total = int(headers.get("content-length", "0"))
+    except Exception:
+        total = 0
+    try:
+        while len(body) < total:
+            chunk = conn.recv(1024)
+            if not chunk:
+                break
+            body += chunk
+    except Exception:
+        pass
+    return method, path, headers, body
+
+
+def send_http(conn, status, ctype, body):
+    if isinstance(body, str):
+        body = body.encode("utf-8")
+    header = ("HTTP/1.1 %s\r\nContent-Type: %s\r\nContent-Length: %d\r\n"
+              "Connection: close\r\nCache-Control: no-store\r\n\r\n") % (status, ctype, len(body))
+    try:
+        conn.send(header.encode("utf-8") + body)
+    except Exception:
+        pass
+
+
+# --------------------------------------------------------------- setup-mode run
+
+def start_ap(config):
+    ap_cfg = config.get("ap", {})
+    ssid = ap_cfg.get("ssid", "Bambutton-Setup")
+    password = ap_cfg.get("password", "bambutton")
+    ap = network.WLAN(network.AP_IF)
+    ap.active(True)
+    try:
+        ap.config(essid=ssid, password=password, authmode=getattr(network, "AUTH_WPA2_PSK", 3))
+    except Exception:
+        try:
+            ap.config(essid=ssid, password=password)
+        except Exception:
+            ap.config(essid=ssid)
+    return ap
+
+
+def run_setup(config):
+    import socket
+    import select
+
+    ap = start_ap(config)
+    try:
+        print("Setup-AP aktiv:", ap.config("essid"), "-> http://%s/" % ap.ifconfig()[0])
+    except Exception:
+        print("Setup-AP aktiv -> http://%s/" % AP_IP)
+
+    http = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    http.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    http.bind(("0.0.0.0", 80))
+    http.listen(4)
+    dns = None
+    try:
+        dns = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        dns.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        dns.bind(("0.0.0.0", 53))
+    except Exception as exc:
+        print("DNS aus:", exc)
+        dns = None
+
+    poller = select.poll()
+    poller.register(http, select.POLLIN)
+    if dns:
+        poller.register(dns, select.POLLIN)
+
+    ctx = {"mode": "setup"}
+    state = {"reset": False}
+    print("Portal laeuft. Auf Verbindung warten ...")
+    while True:
+        for sock, _ev in poller.poll(500):
+            if sock is http:
+                try:
+                    conn, _addr = http.accept()
+                    method, path, _h, body = read_http(conn)
+                    if method is not None:
+                        s, ct, out = route(method, path, body, config, state, ctx)
+                        send_http(conn, s, ct, out)
+                    conn.close()
+                except Exception as exc:
+                    print("HTTP-Fehler:", exc)
+            elif dns and sock is dns:
+                try:
+                    data, addr = dns.recvfrom(512)
+                    resp = build_dns_response(data, AP_IP)
+                    if resp:
+                        dns.sendto(resp, addr)
+                except Exception:
+                    pass
+        if state["reset"]:
+            print("Gespeichert. Neustart in 1s ...")
+            time.sleep(1)
+            if machine:
+                machine.reset()
+            return
+
+
+# ------------------------------------------------------ normal-mode (non-block)
+
+class Server:
+    """Non-blocking config server for normal mode; poll() from the main loop."""
+
+    def __init__(self, config, ctx):
+        import socket
+        self.config = config
+        self.ctx = ctx
+        self.state = {"reset": False}
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind(("0.0.0.0", 80))
+        self.sock.listen(2)
+        self.sock.settimeout(0)
+
+    def poll(self):
+        try:
+            conn, _addr = self.sock.accept()
+        except Exception:
+            return False
+        try:
+            method, path, _h, body = read_http(conn)
+            if method is not None:
+                s, ct, out = route(method, path, body, self.config, self.state, self.ctx)
+                send_http(conn, s, ct, out)
+        except Exception as exc:
+            print("Web-Fehler:", exc)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        return self.state["reset"]
+
+
+PAGE = """<!doctype html><html lang="de"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Bambutton</title><!--INJECT-->
+<style>
+:root{--bg:#0f172a;--card:#fff;--ink:#0f172a;--mut:#64748b;--line:#e2e8f0;--acc:#2563eb;--ok:#059669;--err:#dc2626}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.45 system-ui,Segoe UI,Arial,sans-serif}
+.wrap{max-width:520px;margin:0 auto;padding:16px}
+h1{color:#fff;font-size:20px;margin:12px 4px}.sub{color:#94a3b8;margin:0 4px 14px;font-size:13px}
+.badge{display:inline-block;font-size:11px;color:#cbd5e1;border:1px solid #334155;border-radius:999px;padding:2px 8px;margin-left:6px}
+.card{background:var(--card);border-radius:14px;padding:16px;margin:12px 0;box-shadow:0 6px 20px rgba(0,0,0,.25)}
+.step{font-size:12px;font-weight:700;color:var(--acc);letter-spacing:.04em;text-transform:uppercase;margin:0 0 8px}
+label{display:block;font-size:13px;color:var(--mut);margin:10px 0 4px}
+input,select{width:100%;padding:11px 12px;border:1px solid var(--line);border-radius:10px;font-size:16px;background:#fff;color:var(--ink)}
+.row{display:flex;gap:8px;align-items:center}.row>*{flex:1}
+button{width:100%;padding:13px;border:0;border-radius:10px;background:var(--acc);color:#fff;font-size:16px;font-weight:600;margin-top:14px}
+button:disabled{background:#94a3b8}button.sec{background:#eef2ff;color:var(--acc)}
+.msg{margin-top:10px;font-size:14px;padding:10px 12px;border-radius:10px;display:none}
+.msg.ok{display:block;background:#ecfdf5;color:var(--ok)}.msg.err{display:block;background:#fef2f2;color:var(--err)}.msg.info{display:block;background:#eff6ff;color:var(--acc)}
+.hide{display:none}.pw{position:relative}.pw button{position:absolute;right:6px;top:6px;width:auto;margin:0;padding:6px 10px;background:#eef2ff;color:var(--acc);font-size:12px}
+small{color:var(--mut)}hr{border:0;border-top:1px solid var(--line);margin:14px 0}
+</style></head><body><div class="wrap">
+<h1>Bambutton <span class="badge" id="verBadge"></span></h1>
+<p class="sub" id="lead">WLAN & Bambuddy einrichten, dann Drucker den Knöpfen zuordnen.</p>
+
+<div class="card">
+  <p class="step">1 · WLAN</p>
+  <label>Netzwerk</label>
+  <div class="row">
+    <select id="ssidSel"><option value="">— Netz wählen —</option><option value="__manual__">andere (manuell)…</option></select>
+    <button class="sec" style="flex:0 0 auto;width:auto;margin:0" onclick="loadScan()">↻</button>
+  </div>
+  <input id="ssidManual" class="hide" placeholder="WLAN-Name (SSID)" style="margin-top:8px">
+  <label>Passwort</label>
+  <div class="pw"><input id="pw" type="password" placeholder="WLAN-Passwort"><button onclick="togglePw()">zeigen</button></div>
+  <button onclick="wifiSave()" id="btnWifi" class="hide">WLAN verbinden &amp; speichern</button>
+  <div id="wifiMsg" class="msg"></div>
+</div>
+
+<div class="card">
+  <p class="step">2 · Bambuddy</p>
+  <label>Adresse (IP:Port)</label>
+  <input id="host" placeholder="z. B. 192.168.1.50:8000" inputmode="url">
+  <label>API-Key</label>
+  <input id="key" placeholder="Bambuddy API-Key">
+  <button onclick="primaryAction()" id="btnTest">Verbindung testen</button>
+  <div id="testMsg" class="msg"></div>
+</div>
+
+<div class="card hide" id="cardStations">
+  <p class="step">3 · Knöpfe zuordnen</p>
+  <label>Knopf A (GP3 / GP4)</label>
+  <div class="row"><select id="stA" onchange="identify(0)"></select><button class="sec" style="flex:0 0 auto;width:auto;margin:0" onclick="identify(0)">🔦</button></div>
+  <label>Knopf B (GP5 / GP6)</label>
+  <div class="row"><select id="stB" onchange="identify(1)"></select><button class="sec" style="flex:0 0 auto;width:auto;margin:0" onclick="identify(1)">🔦</button></div>
+  <small>Tipp: 🔦 lässt den passenden Knopf ~4 s blinken.</small>
+  <button onclick="save()" id="btnSave">Speichern & Neustart</button>
+  <div id="saveMsg" class="msg"></div>
+</div>
+
+<div class="card hide" id="cardUpdate">
+  <p class="step">4 · Update (OTA)</p>
+  <label>Update-URL (GitHub raw, optional)</label>
+  <input id="updUrl" placeholder="https://…/ (Ordner mit manifest.json)">
+  <button class="sec" onclick="updateGit()" id="btnUpd">Aus dem Internet aktualisieren</button>
+  <hr>
+  <label>Oder Dateien hochladen (.py / .json)</label>
+  <input id="files" type="file" multiple accept=".py,.json">
+  <button class="sec" onclick="uploadFiles()" id="btnUpl">Hochladen & Neustart</button>
+  <div id="updMsg" class="msg"></div>
+</div>
+<p class="sub">Beim Verbindungstest kann sich dein Handy kurz neu mit „Bambutton-Setup" verbinden — das ist normal.</p>
+</div>
+<script>
+var MODE=window.MODE||'setup',CFG=window.CFG||{},VERSION=window.VERSION||'';
+var printers=[];
+function $(i){return document.getElementById(i)}
+function togglePw(){var i=$('pw');i.type=i.type==='password'?'text':'password'}
+$('ssidSel').addEventListener('change',function(){$('ssidManual').classList.toggle('hide',this.value!=='__manual__')});
+function ssidVal(){var s=$('ssidSel').value;return s==='__manual__'?$('ssidManual').value.trim():s}
+function setMsg(id,cls,txt){var m=$(id);m.className='msg '+cls;m.textContent=txt}
+function loadScan(){fetch('/scan').then(r=>r.json()).then(function(d){
+  var s=$('ssidSel'),cur=s.value;s.innerHTML='<option value="">— Netz wählen —</option>';
+  (d.networks||[]).forEach(function(n){var o=document.createElement('option');o.value=n.ssid;o.textContent=n.ssid+'  ('+n.rssi+' dBm)';s.appendChild(o)});
+  var m=document.createElement('option');m.value='__manual__';m.textContent='andere (manuell)…';s.appendChild(m);
+  if(cur)s.value=cur;
+}).catch(function(){})}
+function opts(sel,cur){var s=$(sel);s.innerHTML='<option value="">— kein Drucker —</option>';
+  printers.forEach(function(p){var o=document.createElement('option');o.value=p.id;o.textContent=p.label;s.appendChild(o)});
+  if(cur!==undefined&&cur!==null&&cur!=='')s.value=String(cur)}
+function stCur(i){var a=(CFG.stations||[]).filter(function(x){return x.index===i});return a.length?a[0].printer_id:''}
+function fillStations(){opts('stA',stCur(0));opts('stB',stCur(1))}
+function identify(i){fetch('/identify',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({index:i})}).catch(function(){})}
+function primaryAction(){if(MODE==='normal'){loadPrinters()}else{testConn()}}
+function testConn(){setMsg('testMsg','info','Teste… (kann ~15 s dauern)');$('btnTest').disabled=true;
+  var b={ssid:ssidVal(),password:$('pw').value,host:$('host').value.trim(),key:$('key').value.trim()};
+  fetch('/test',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(b)}).then(r=>r.json()).then(function(d){
+    $('btnTest').disabled=false;
+    if(d.ok){printers=d.printers||[];setMsg('testMsg','ok','Verbunden! '+printers.length+' Drucker gefunden.');fillStations();$('cardStations').classList.remove('hide')}
+    else{setMsg('testMsg','err',d.error||'Fehlgeschlagen.')}
+  }).catch(function(){$('btnTest').disabled=false;setMsg('testMsg','err','Keine Antwort (Handy evtl. kurz getrennt) — nochmal.')})}
+function loadPrinters(){setMsg('testMsg','info','Lade Drucker…');$('btnTest').disabled=true;
+  fetch('/probe',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:$('host').value.trim(),key:$('key').value.trim()})}).then(r=>r.json()).then(function(d){$('btnTest').disabled=false;
+    if(d.ok){printers=d.printers||[];setMsg('testMsg','ok',printers.length+' Drucker geladen.');fillStations();$('cardStations').classList.remove('hide')}
+    else{setMsg('testMsg','err',d.error||'Fehlgeschlagen.')}
+  }).catch(function(){$('btnTest').disabled=false;setMsg('testMsg','err','Nicht ladbar.')})}
+function wifiSave(){var s=ssidVal();if(!s){setMsg('wifiMsg','err','Bitte WLAN wählen.');return}
+  setMsg('wifiMsg','info','Verbinde… (~15 s)');$('btnWifi').disabled=true;
+  fetch('/wifitest',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid:s,password:$('pw').value})}).then(r=>r.json()).then(function(d){
+    if(!d.ok){$('btnWifi').disabled=false;setMsg('wifiMsg','err',d.error||'WLAN fehlgeschlagen.');return}
+    var ip=d.ip||'?';setMsg('wifiMsg','info','Verbunden ('+ip+'). Speichere…');
+    fetch('/save',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid:s,password:$('pw').value})}).then(r=>r.json()).then(function(){
+      setMsg('wifiMsg','ok','Gespeichert! Der Button startet neu und ist dann unter http://'+ip+'/ erreichbar — dort am PC Bambuddy + Drucker einrichten.');
+    }).catch(function(){setMsg('wifiMsg','ok','Gespeichert — Neustart. Danach unter http://'+ip+'/ erreichbar.');});
+  }).catch(function(){$('btnWifi').disabled=false;setMsg('wifiMsg','err','Keine Antwort — bitte nochmal.')});}
+function save(){setMsg('saveMsg','info','Speichere…');$('btnSave').disabled=true;
+  var b={ssid:ssidVal(),password:$('pw').value,host:$('host').value.trim(),key:$('key').value.trim(),
+    stations:[{index:0,printer_id:$('stA').value},{index:1,printer_id:$('stB').value}]};
+  fetch('/save',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(b)}).then(r=>r.json()).then(function(d){
+    if(d.ok){setMsg('saveMsg','ok','Gespeichert! Button startet neu. Fenster kann zu.')}else{$('btnSave').disabled=false;setMsg('saveMsg','err',d.error||'Fehler.')}
+  }).catch(function(){setMsg('saveMsg','ok','Gespeichert — Button startet neu (Verbindung getrennt).')})}
+function updateGit(){setMsg('updMsg','info','Hole Update…');$('btnUpd').disabled=true;
+  fetch('/update',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({url:$('updUrl').value.trim()})}).then(r=>r.json()).then(function(d){
+    if(d.ok){setMsg('updMsg','ok','Update '+(d.version||'')+' geladen ('+(d.files||[]).length+' Dateien). Neustart…')}
+    else{$('btnUpd').disabled=false;setMsg('updMsg','err',d.error||'Fehler.')}
+  }).catch(function(){setMsg('updMsg','ok','Vermutlich aktualisiert — Button startet neu.')})}
+function uploadFiles(){var fs=$('files').files;if(!fs.length){setMsg('updMsg','err','Keine Dateien gewählt.');return}
+  setMsg('updMsg','info','Lade hoch…');$('btnUpl').disabled=true;var arr=[].slice.call(fs);
+  function one(i){if(i>=arr.length){fetch('/reboot',{method:'POST'});setMsg('updMsg','ok',arr.length+' Dateien hochgeladen. Neustart…');return}
+    var f=arr[i],rd=new FileReader();rd.onload=function(){
+      fetch('/upload',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({filename:f.name,content:rd.result})})
+       .then(r=>r.json()).then(function(d){if(!d.ok){$('btnUpl').disabled=false;setMsg('updMsg','err',f.name+': '+(d.error||'Fehler'))}else{one(i+1)}})
+       .catch(function(){$('btnUpl').disabled=false;setMsg('updMsg','err','Upload-Fehler bei '+f.name)})};
+    rd.readAsText(f)}
+  one(0)}
+(function init(){
+  $('verBadge').textContent='v'+VERSION;
+  if(MODE==='normal'){
+    $('lead').textContent='Verbunden. Drucker neu zuordnen, Einstellungen ändern oder aktualisieren.';
+    if(CFG.ssid){var s=$('ssidSel');var o=document.createElement('option');o.value=CFG.ssid;o.textContent=CFG.ssid+' (aktuell)';s.appendChild(o);s.value=CFG.ssid}
+    $('pw').placeholder='unverändert lassen';
+    $('host').value=CFG.host||'';$('key').placeholder='unverändert lassen';
+    $('btnTest').textContent='Drucker neu laden';
+    $('updUrl').value=CFG.update_url||'';
+    $('cardUpdate').classList.remove('hide');
+    loadPrinters();loadScan();
+  }else{
+    $('lead').textContent='Nur WLAN wählen und speichern — Bambuddy + Drucker richtest du danach bequem am PC über die Button-IP ein.';
+    $('btnWifi').classList.remove('hide');
+    loadScan();
+  }
+})();
+</script></body></html>"""

--- a/tests/fakes/machine.py
+++ b/tests/fakes/machine.py
@@ -1,0 +1,17 @@
+class Pin:
+    OUT=1; IN=0; PULL_UP=2; PULL_DOWN=3; IRQ_RISING=4; IRQ_FALLING=8
+    def __init__(self, num, mode=None, pull=None):
+        self.num=num; self.mode=mode; self.pull=pull; self._v=0; self._handler=None
+    def value(self, v=None):
+        if v is None: return self._v
+        self._v = 1 if v else 0
+    def irq(self, trigger=None, handler=None):
+        self._handler=handler
+class WDT:
+    def __init__(self, timeout=0): pass
+    def feed(self): pass
+class Timer:
+    PERIODIC=1; ONE_SHOT=0
+    def __init__(self, id=-1): self.id=id; self.cb=None
+    def init(self, period=0, mode=1, callback=None): self.cb=callback
+    def deinit(self): pass

--- a/tests/fakes/network.py
+++ b/tests/fakes/network.py
@@ -1,0 +1,21 @@
+STA_IF=0
+AP_IF=1
+AUTH_WPA2_PSK=3
+def hostname(name=None):
+    return name
+class WLAN:
+    def __init__(self, mode=0):
+        self.mode=mode; self._conn=False; self._cfg={"essid":"Bambutton-Setup"}
+    def active(self, v=None): return True
+    def isconnected(self): return self._conn
+    def connect(self, ssid, pw): self._conn=True
+    def disconnect(self): self._conn=False
+    def ifconfig(self): return ("192.168.4.1","255.255.255.0","192.168.4.1","192.168.4.1")
+    def config(self, *a, **k):
+        if a: return self._cfg.get(a[0], "")
+        self._cfg.update(k); return None
+    def scan(self):
+        return [(b"HomeWiFi", b"\x00"*6, 11, -55, 3, False),
+                (b"HomeWiFi", b"\x00"*6, 6, -74, 3, False),
+                (b"GuestWiFi", b"\x00"*6, 11, -56, 3, False),
+                (b"", b"\x00"*6, 11, -58, 3, False)]

--- a/tests/fakes/urequests.py
+++ b/tests/fakes/urequests.py
@@ -1,0 +1,5 @@
+class _Resp:
+    status_code=200; text="[]"
+    def close(self): pass
+def get(*a, **k): return _Resp()
+def post(*a, **k): return _Resp()

--- a/tests/test_micro.py
+++ b/tests/test_micro.py
@@ -1,0 +1,346 @@
+"""Host-side tests for the Bambutton multi-station firmware.
+
+These run under CPython using the light-weight fakes in tests/fakes/
+(machine, network, urequests) that stand in for the MicroPython runtime, so
+no board and no network are required:
+
+    python tests/test_micro.py
+
+They cover the config schema (incl. legacy migration), printer-name
+resolution, the on-device web/setup layer, the boot decision and the
+per-station LED logic.
+"""
+import os
+import sys
+import json
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "fakes"))
+sys.path.insert(0, os.path.join(HERE, "..", "micro"))
+
+import config_loader
+import bb_util
+import webconfig
+import main
+import runner
+
+
+# ---------------------------------------------------------------------------
+# config_loader
+# ---------------------------------------------------------------------------
+def test_defaults():
+    cfg = config_loader.load_config(os.path.join(tempfile.mkdtemp(), "none.json"))
+    assert len(cfg["stations"]) == 2
+    assert cfg["update"]["url"] == ""
+    assert cfg["ap"]["ssid"] == "Bambutton-Setup"
+    print("defaults OK")
+
+
+def test_config_complete():
+    complete = {"wifi": {"ssid": "HomeWiFi"},
+                "api": {"base_url": "http://192.168.1.50:8000/api/v1", "key": "k"},
+                "stations": [{"printer_id": "X1C"}, {"printer_id": ""}]}
+    assert config_loader.config_complete(complete) is True
+    assert config_loader.config_complete(
+        {"wifi": {"ssid": ""}, "api": {}, "stations": []}) is False
+    no_printer = dict(complete)
+    no_printer["stations"] = [{"printer_id": ""}, {"printer_id": ""}]
+    assert config_loader.config_complete(no_printer) is False
+    print("config_complete OK")
+
+
+def test_legacy_migration():
+    # An old single-printer config (as the desktop assistant writes) must keep
+    # working: printer{}/led.pin/button.pin fold into station 0.
+    path = os.path.join(tempfile.mkdtemp(), "config.json")
+    with open(path, "w") as f:
+        json.dump({"wifi": {"ssid": "HomeWiFi", "password": "p"},
+                   "api": {"base_url": "http://192.168.1.50:8000/api/v1", "key": "k"},
+                   "printer": {"id": 7, "poll_interval_seconds": 5},
+                   "led": {"pin": 8}, "button": {"pin": 9}}, f)
+    cfg = config_loader.load_config(path)
+    assert cfg["stations"][0]["printer_id"] == "7"
+    assert cfg["stations"][0]["led_pin"] == 8
+    assert cfg["stations"][0]["button_pin"] == 9
+    assert cfg["poll_interval_seconds"] == 5
+    print("legacy_migration OK")
+
+
+def test_save_load_roundtrip():
+    os.chdir(tempfile.mkdtemp())
+    cfg = config_loader.load_config("config.json")
+    cfg["wifi"]["ssid"] = "HomeWiFi"
+    config_loader.save_config(cfg, "config.json")
+    assert config_loader.load_config("config.json")["wifi"]["ssid"] == "HomeWiFi"
+    print("save_load_roundtrip OK")
+
+
+# ---------------------------------------------------------------------------
+# bb_util
+# ---------------------------------------------------------------------------
+def test_normalize_base_url():
+    n = bb_util.normalize_base_url
+    assert n("192.168.1.50:8000") == "http://192.168.1.50:8000/api/v1"
+    assert n("http://192.168.1.50:8000") == "http://192.168.1.50:8000/api/v1"
+    assert n("http://192.168.1.50:8000/api/v1/") == "http://192.168.1.50:8000/api/v1"
+    assert n("") == ""
+    print("normalize_base_url OK")
+
+
+def test_match_printer_id():
+    nm = bb_util.build_name_map([{"id": 7, "friendly_name": "BambuLab X1C 3D"},
+                                 {"id": 9, "friendly_name": "BambuLab P1S 3D"}])
+    assert bb_util.match_printer_id("X1C", nm) == 7        # contains, case-insensitive
+    assert bb_util.match_printer_id("p1s", nm) == 9
+    assert bb_util.match_printer_id("7", nm) == 7          # numeric passthrough
+    assert bb_util.match_printer_id("BambuLab", nm) is None  # ambiguous
+    assert bb_util.match_printer_id("nope", nm) is None
+    print("match_printer_id OK")
+
+
+# ---------------------------------------------------------------------------
+# webconfig – parsing / rendering / DNS
+# ---------------------------------------------------------------------------
+def test_parse_and_ipport():
+    m, p, h = webconfig.parse_request(b"POST /save HTTP/1.1\r\nContent-Length: 5")
+    assert m == "POST" and p == "/save" and h["content-length"] == "5"
+    assert webconfig.ip_port_from_base_url(
+        "http://192.168.1.50:8000/api/v1") == "192.168.1.50:8000"
+    assert webconfig.ip_port_from_base_url("") == ""
+    print("parse_and_ipport OK")
+
+
+def test_dns_captive():
+    q = b"\xab\xcd\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x03abc\x03com\x00\x00\x01\x00\x01"
+    r = webconfig.build_dns_response(q, "192.168.4.1")
+    assert r[:2] == b"\xab\xcd" and r[-4:] == bytes([192, 168, 4, 1])
+    print("dns_captive OK")
+
+
+def base_config():
+    return config_loader.load_config(os.path.join(tempfile.mkdtemp(), "none.json"))
+
+
+def test_render_page_normal():
+    c = base_config()
+    c["wifi"]["ssid"] = "HomeWiFi"
+    c["api"]["base_url"] = "http://192.168.1.50:8000/api/v1"
+    c["stations"][0]["printer_id"] = "7"
+    html = webconfig.render_page(c, "normal")
+    assert "<!--INJECT-->" not in html
+    assert 'window.MODE="normal"' in html.replace(" ", "")
+    assert "192.168.1.50:8000" in html
+    assert "HomeWiFi" in html
+    print("render_page_normal OK")
+
+
+def test_route_html_and_scan():
+    s, ct, body = webconfig.route("GET", "/", b"", base_config(), {"reset": False})
+    assert s.startswith("200") and "text/html" in ct and "Bambutton" in body
+    s2, ct2, body2 = webconfig.route("GET", "/scan", b"", base_config(), {"reset": False})
+    ssids = [n["ssid"] for n in json.loads(body2)["networks"]]
+    assert "HomeWiFi" in ssids and ssids.count("HomeWiFi") == 1   # deduped
+    print("route_html_and_scan OK")
+
+
+# ---------------------------------------------------------------------------
+# webconfig – Bambuddy probe / Wi-Fi test (with a fake API)
+# ---------------------------------------------------------------------------
+class FakeAPI:
+    def __init__(self, *a, **k):
+        pass
+
+    def get_printers(self):
+        return [{"id": 7, "friendly_name": "BambuLab X1C 3D"},
+                {"id": 9, "friendly_name": "BambuLab P1S 3D"}]
+
+
+def test_probe():
+    webconfig.bambuddy_api.BambuddyAPI = lambda *a, **k: FakeAPI()
+    r = webconfig.do_probe({"host": "192.168.1.50:8000", "key": "k"}, {})
+    assert r["ok"] is True and 7 in [p["id"] for p in r["printers"]]
+    saved = {"api": {"base_url": "http://192.168.1.50:8000/api/v1", "key": "savedkey"}}
+    assert webconfig.do_probe({}, saved)["ok"] is True     # falls back to saved
+    assert webconfig.do_probe({}, {})["ok"] is False       # nothing to probe
+    print("probe OK")
+
+
+def test_wifitest():
+    webconfig.sta_connect = lambda ssid, pw, timeout=15: True
+    r = webconfig.do_wifitest({"ssid": "HomeWiFi", "password": "x"})
+    assert r["ok"] is True and r["ip"] == "192.168.4.1"
+    webconfig.sta_connect = lambda ssid, pw, timeout=15: False
+    assert webconfig.do_wifitest({"ssid": "HomeWiFi", "password": "bad"})["ok"] is False
+    assert webconfig.do_wifitest({"ssid": ""})["ok"] is False
+    print("wifitest OK")
+
+
+def test_do_test_combined():
+    webconfig.sta_connect = lambda ssid, pw, timeout=15: True
+    webconfig.bambuddy_api.BambuddyAPI = lambda *a, **k: FakeAPI()
+    r = webconfig.do_test({"ssid": "HomeWiFi", "password": "p",
+                           "host": "192.168.1.50:8000", "key": "k"})
+    assert r["ok"] is True and "BambuLab X1C 3D" in [p["label"] for p in r["printers"]]
+    print("do_test_combined OK")
+
+
+# ---------------------------------------------------------------------------
+# webconfig – save keeps secrets, upload/OTA safety
+# ---------------------------------------------------------------------------
+def test_save_keeps_secrets():
+    os.chdir(tempfile.mkdtemp())
+    cfg = base_config()
+    cfg["wifi"]["password"] = "oldpw"
+    cfg["api"]["key"] = "oldkey"
+    cfg["api"]["base_url"] = "http://192.168.1.1:8000/api/v1"
+    st = {"reset": False}
+    r = webconfig.do_save({"ssid": "HomeWiFi", "password": "", "host": "192.168.1.50:8000",
+                           "key": "", "stations": [{"index": 0, "printer_id": "7"},
+                                                    {"index": 1, "printer_id": "9"}]}, cfg, st)
+    assert r["ok"] is True and st["reset"] is True
+    saved = config_loader.load_config("config.json")
+    assert saved["wifi"]["password"] == "oldpw"      # blank -> kept
+    assert saved["api"]["key"] == "oldkey"           # blank -> kept
+    assert saved["api"]["base_url"] == "http://192.168.1.50:8000/api/v1"  # updated
+    assert saved["wifi"]["ssid"] == "HomeWiFi"
+    assert saved["stations"][0]["printer_id"] == "7" and saved["stations"][1]["printer_id"] == "9"
+    print("save_keeps_secrets OK")
+
+
+def test_upload_path_safety():
+    os.chdir(tempfile.mkdtemp())
+    assert webconfig.do_upload({"filename": "runner.py", "content": "# NEW\n"})["ok"] is True
+    assert open("runner.py").read() == "# NEW\n"
+    assert webconfig.do_upload({"filename": "../evil.py", "content": "x"})["ok"] is False
+    assert webconfig.do_upload({"filename": "evil.txt", "content": "x"})["ok"] is False
+    assert webconfig.do_upload({"filename": "a/b.py", "content": "x"})["ok"] is False
+    assert webconfig.do_upload({"filename": "main.py", "content": 123})["ok"] is False
+    print("upload_path_safety OK")
+
+
+def test_ota_update():
+    os.chdir(tempfile.mkdtemp())
+    manifest = json.dumps({"version": "9.9", "files": ["main.py", "runner.py"]})
+
+    def fake_get(url, timeout=10):
+        if url.endswith("/manifest.json"):
+            return manifest
+        return "# OTA CODE for " + url.rsplit("/", 1)[-1] + "\n"
+
+    webconfig._http_get_text = fake_get
+    cfg = base_config()
+    st = {"reset": False}
+    r = webconfig.do_update({"url": "https://example.test/bb/"}, cfg, st)
+    assert r["ok"] is True and r["version"] == "9.9" and st["reset"] is True
+    assert set(r["files"]) == {"main.py", "runner.py"}
+    assert "OTA CODE for main.py" in open("main.py").read()
+
+    def fake_get_unsafe(url, timeout=10):
+        if url.endswith("/manifest.json"):
+            return json.dumps({"version": "1", "files": ["../evil.py"]})
+        return "x"
+
+    webconfig._http_get_text = fake_get_unsafe
+    assert webconfig.do_update({"url": "https://x/"}, base_config(), {"reset": False})["ok"] is False
+    print("ota_update OK")
+
+
+# ---------------------------------------------------------------------------
+# main.decide_setup
+# ---------------------------------------------------------------------------
+def test_decide_setup():
+    complete = {"wifi": {"ssid": "HomeWiFi"},
+                "api": {"base_url": "h", "key": "k"}, "stations": [{"printer_id": "7"}]}
+    assert main.decide_setup(complete, True)[0] is True       # button held
+    assert main.decide_setup(complete, False)[0] is False     # runs normally
+    assert main.decide_setup({"wifi": {"ssid": ""}}, False)[0] is True  # no Wi-Fi
+    print("decide_setup OK")
+
+
+# ---------------------------------------------------------------------------
+# runner – stations, LED logic, identify, id resolution
+# ---------------------------------------------------------------------------
+def two_stations(a="", b=""):
+    return {"button": {}, "stations": [
+        {"printer_id": a, "led_pin": 3, "button_pin": 4},
+        {"printer_id": b, "led_pin": 5, "button_pin": 6}]}
+
+
+def test_build_stations_active_flags():
+    sts = runner.build_stations(two_stations("X1C", ""))
+    assert len(sts) == 2 and sts[0].active is True and sts[1].active is False
+    print("build_stations_active_flags OK")
+
+
+def test_led_inactive_is_dark():
+    st = runner.build_stations(two_stations("", ""))[0]
+    st.led.value(1)
+    st.update_led()
+    assert st.led.value() == 0
+    print("led_inactive_is_dark OK")
+
+
+def test_led_identify_blinks_even_when_inactive():
+    st = runner.build_stations(two_stations("", ""))[0]
+    st.led.value(0)
+    st.identify(4)
+    st.update_led(); assert st.led.value() == 1
+    st.update_led(); assert st.led.value() == 0
+    st.identify_until = runner._now_ms() - 100   # window elapsed
+    st.update_led(); assert st.led.value() == 0
+    print("led_identify_blinks OK")
+
+
+def test_led_active_follows_chamber_and_awaiting():
+    st = runner.build_stations(two_stations("X1C", ""))[0]
+    st.printer_id = 7
+    st.awaiting_plate_clear = False
+    st.chamber_light_on = True
+    st.update_led(); assert st.led.value() == 1        # chamber on -> steady on
+    st.chamber_light_on = False
+    st.update_led(); assert st.led.value() == 0        # chamber off -> off
+    st.awaiting_plate_clear = True
+    st.led.value(0); st.update_led(); assert st.led.value() == 1   # awaiting -> blink
+    print("led_active_logic OK")
+
+
+def test_build_api_guards():
+    assert runner.build_api({"api": {"base_url": "", "key": ""}}) is None
+    assert runner.build_api({"api": {"base_url": "192.168.1.50:8000", "key": ""}}) is None
+    runner.bambuddy_api.BambuddyAPI = lambda *a, **k: FakeAPI()
+    assert runner.build_api({"api": {"base_url": "192.168.1.50:8000", "key": "k"}}) is not None
+    print("build_api_guards OK")
+
+
+class _Net:
+    def ensure_connected(self):
+        return True
+
+
+def test_resolve_station_ids():
+    st = runner.build_stations(two_stations("X1C", ""))[0]
+    api = FakeAPI()
+    assert runner.resolve_station_ids(api, _Net(), [st]) is True
+    assert st.printer_id == 7
+    print("resolve_station_ids OK")
+
+
+def test_identify_route():
+    sts = runner.build_stations(two_stations("X1C", "P1S"))
+    ctx = {"mode": "normal", "stations": sts}
+    assert webconfig.do_identify({"index": 1}, ctx)["ok"] is True
+    assert sts[1].identify_until > 0
+    assert webconfig.do_identify({"index": 9}, ctx)["ok"] is False
+    assert webconfig.do_identify({"index": 0}, {"mode": "setup"})["ok"] is False
+    s, ct, body = webconfig.route("POST", "/identify", b'{"index":0}', {}, {"reset": False}, ctx)
+    assert "application/json" in ct and json.loads(body)["ok"] is True
+    print("identify_route OK")
+
+
+ALL = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+
+if __name__ == "__main__":
+    for fn in ALL:
+        fn()
+    print("\nALL %d TESTS PASSED" % len(ALL))


### PR DESCRIPTION
## What this adds

This is an **additive** third setup route that sits alongside the existing desktop Setup Assistant GUI and manual flashing — it does not replace them. The board becomes configurable from a phone/browser, can drive more than one printer, and can update its own app code without a cable.

- **On-device setup portal.** On first boot — or whenever no Wi-Fi is stored, or the button is held at power-on — the board opens a `Bambutton-Setup` access point with a captive page to store Wi-Fi. After it joins the network, the *same* page is served on the board's LAN IP (`http://<board-ip>/`) to enter the Bambuddy address + API key, test the connection, and assign a printer to each button. Wi-Fi and Bambuddy are separate steps, so Wi-Fi can be saved from a phone on a guest network and Bambuddy finished later from a PC on the LAN.
- **Multiple printers on one board.** Config now carries a `stations` list — each station is one printer with its own button and LED — so a single ESP32-C3 can serve two (or more) buttons/printers. One Bambuddy API key serves all stations. A 🔦 *identify* control in the UI blinks a chosen station's LED so buttons are easy to tell apart.
- **OTA updates (optional).** The portal can update the app code (`micro/*.py`, not the MicroPython firmware itself) by pulling a `manifest.json` + files from a URL, or by uploading `.py`/`.json` from the browser.
- **Network hostname.** The board announces a configurable DHCP hostname (default `bambutton`) before Wi-Fi comes up, so it shows up by name in the router/client list instead of a generic chip name.

## Backward compatibility

Existing single-printer `config.json` files (the `printer` / `led.pin` / `button.pin` schema the GUI writes) are **migrated automatically** into the first station on load, so boards configured the old way keep working. The bundled MicroPython firmware `.bin` is unchanged.

## Changes

- New modules: `micro/runner.py` (normal-mode loop: multi-station polling, LED logic, LAN config server), `micro/webconfig.py` (AP captive page + LAN config page, OTA, identify), `micro/provisioning.py` (setup-mode entry point), `micro/bb_util.py` (URL normalising + printer-name matching).
- `micro/main.py` reworked into a small boot orchestrator (`decide_setup` → provisioning or runner), now importable/testable.
- `micro/config_loader.py` gains the multi-station schema, `save_config`, `config_complete`, and the legacy-config migration.
- `micro/config_example.json` updated to the station schema.
- `README.md` documents the portal, multi-printer wiring, OTA, and compatibility.

## Testing

Host-side tests run under CPython with small MicroPython fakes (no board/network needed):

```bash
python tests/test_micro.py
```

24 checks cover the config schema + legacy migration, printer-name resolution, the web layer (parsing, DNS, rendering, probe, Wi-Fi test, secret-preserving save, upload/OTA path-safety, identify), the boot decision, and per-station LED behaviour.

## Notes / happy to adjust

- The desktop GUI still writes the legacy single-printer schema; it works through the migration path, but updating the GUI to write `stations` (and expose a second printer) would be a natural follow-up — glad to do that separately.
- This is a fairly large change. If you'd prefer, I'm happy to split it into smaller PRs (e.g. multi-station support, then the web portal, then OTA) or turn anything off by default.

