### PR TITLE
fix: disable Wi-Fi power saving

### DIFF
--- a/micro/wifi.py
+++ b/micro/wifi.py
@@ -28,6 +28,7 @@ class WiFi:
         network.hostname(DEFAULT_HOSTNAME)
         self.wlan.active(True)
         # self.wlan.config(txpower=8.5)
+        self.wlan.config(pm=network.WLAN.PM_NONE)
 
         if not self.wlan.isconnected():
             print("Connecting to Wi-Fi:", self.ssid)

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -9,11 +9,18 @@ WIFI_PATH = Path(__file__).parents[1] / "micro" / "wifi.py"
 
 def load_wifi_module(monkeypatch, events):
     class FakeWLAN:
+        PM_NONE = "pm-none"
+
         def __init__(self, interface):
             self.connected = False
+            self.config_calls = []
 
         def active(self, enabled):
             events.append(("active", enabled))
+
+        def config(self, **kwargs):
+            self.config_calls.append(kwargs)
+            events.append(("config", kwargs))
 
         def connect(self, ssid, password):
             events.append(("connect", ssid, password))
@@ -49,8 +56,18 @@ def test_connect_sets_default_hostname_before_activating_wifi(monkeypatch):
 
     wifi_module.WiFi("ssid", "password").connect()
 
-    assert events[:3] == [
+    assert events[:4] == [
         ("hostname", "bambutton"),
         ("active", True),
+        ("config", {"pm": "pm-none"}),
         ("connect", "ssid", "password"),
     ]
+
+
+def test_connect_disables_wifi_power_management(monkeypatch):
+    wifi_module = load_wifi_module(monkeypatch, [])
+    wifi = wifi_module.WiFi("ssid", "password")
+
+    wlan = wifi.connect()
+
+    assert wlan.config_calls == [{"pm": "pm-none"}]


### PR DESCRIPTION
Closes #10. Configure the ESP32 station interface with WLAN.PM_NONE so Wi-Fi power saving cannot make the physical button appear unresponsive. Adds a regression test for the power-management configuration call.\n\nValidation: python3 -m py_compile micro/wifi.py tests/test_wifi.py; pytest and flake8 were unavailable in the local environment.