### PR TITLE
feat: set default network hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Key files:
 - `src/bambutton/gui.py` - GUI for selecting firmware, board, pins, Wi-Fi, API key, and printer.
 - `src/bambutton_config_gui.py` - compatibility launcher for running the GUI from source.
 
+The firmware sets the board's network hostname to `bambutton` before connecting to Wi-Fi,
+so DHCP and mDNS-capable networks can identify it more easily.
+
 ## Setup Assistant GUI
 
 For end users, use the built installer when available.

--- a/micro/wifi.py
+++ b/micro/wifi.py
@@ -2,6 +2,9 @@ import network
 import time
 
 
+DEFAULT_HOSTNAME = "bambutton"
+
+
 class WiFi:
     def __init__(
         self,
@@ -21,6 +24,8 @@ class WiFi:
         self.wlan = network.WLAN(network.STA_IF)
 
     def connect(self):
+        # Set this before activating the interface so DHCP and mDNS can use it.
+        network.hostname(DEFAULT_HOSTNAME)
         self.wlan.active(True)
         # self.wlan.config(txpower=8.5)
 

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -1,0 +1,56 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+WIFI_PATH = Path(__file__).parents[1] / "micro" / "wifi.py"
+
+
+def load_wifi_module(monkeypatch, events):
+    class FakeWLAN:
+        def __init__(self, interface):
+            self.connected = False
+
+        def active(self, enabled):
+            events.append(("active", enabled))
+
+        def connect(self, ssid, password):
+            events.append(("connect", ssid, password))
+            self.connected = True
+
+        def isconnected(self):
+            return self.connected
+
+        def ifconfig(self):
+            return ("192.168.1.20", "255.255.255.0", "192.168.1.1", "192.168.1.1")
+
+    def set_hostname(hostname):
+        events.append(("hostname", hostname))
+
+    fake_network = SimpleNamespace(STA_IF=0, WLAN=FakeWLAN, hostname=set_hostname)
+    fake_time = SimpleNamespace(
+        ticks_ms=lambda: 0,
+        ticks_diff=lambda current, start: current - start,
+        sleep=lambda seconds: None,
+    )
+    monkeypatch.setitem(sys.modules, "network", fake_network)
+    monkeypatch.setitem(sys.modules, "time", fake_time)
+
+    spec = importlib.util.spec_from_file_location("test_wifi_module", WIFI_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_connect_sets_default_hostname_before_activating_wifi(monkeypatch):
+    events = []
+    wifi_module = load_wifi_module(monkeypatch, events)
+
+    wifi_module.WiFi("ssid", "password").connect()
+
+    assert events[:3] == [
+        ("hostname", "bambutton"),
+        ("active", True),
+        ("connect", "ssid", "password"),
+    ]


### PR DESCRIPTION
## Summary
- set the MicroPython network hostname to `bambutton` before Wi-Fi activation
- document the improved DHCP/mDNS device discovery
- add a regression test for hostname setup order

## Verification
- `python3 -m py_compile micro/wifi.py tests/test_wifi.py`
- fake MicroPython runtime regression check passed
- full pytest suite not run because pytest is not installed in this environment

Closes #12