### PR TITLE
feat: add web configuration and debug UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ Key files:
 The firmware sets the board's network hostname to `bambutton` before connecting to Wi-Fi,
 so DHCP and mDNS-capable networks can identify it more easily.
 
+## Web Configuration
+
+After the board joins its configured Wi-Fi network, open `http://bambutton/` or
+the board's assigned IP address in a browser. The built-in configuration page
+can update the hostname, Wi-Fi credentials, Bambuddy API details, printer, and
+GPIO pins without a USB connection. Use **Load printers from Bambuddy** to
+populate the printer selector from the configured API.
+
+Saving settings writes the board's `config.json` and restarts the firmware so
+changes such as a new Wi-Fi network or hostname take effect. The debug page
+shows current network and application state without exposing the API key or
+Wi-Fi password. The page is available only on the existing Wi-Fi network; the
+firmware does not create an access point.
+
 ## Setup Assistant GUI
 
 For end users, use the built installer when available.

--- a/micro/config_example.json
+++ b/micro/config_example.json
@@ -2,6 +2,7 @@
   "wifi": {
     "ssid": "YOUR WIFI SSID",
     "password": "YOUR WIFI PASSWORD",
+    "hostname": "bambutton",
     "timeout_seconds": 10
   },
   "api": {

--- a/micro/config_loader.py
+++ b/micro/config_loader.py
@@ -8,6 +8,7 @@ DEFAULT_CONFIG = {
     "wifi": {
         "ssid": "",
         "password": "",
+        "hostname": "bambutton",
         "timeout_seconds": 10,
     },
     "api": {

--- a/micro/main.py
+++ b/micro/main.py
@@ -1,11 +1,12 @@
+import machine
 import time
-from machine import WDT
 import bambuddy_api
 import config_loader
 import gpio_button
 import led_flasher
 import wifi
 import periodic_timer
+import web_config
 
 
 config = config_loader.load_config()
@@ -18,7 +19,7 @@ PRINTER_STATUS_UPDATE_REQUIRED = True
 
 # Feed this only from the healthy main loop. If a network request or the
 # networking stack blocks, the board will reboot and reconnect from scratch.
-watchdog = WDT(timeout=60_000)
+watchdog = machine.WDT(timeout=60_000)
 
 # -- Initialize LED flasher ---
 flasher = led_flasher.LedFlasher(
@@ -59,6 +60,7 @@ try:
     network = wifi.WiFi(
         ssid=config["wifi"]["ssid"],
         password=config["wifi"]["password"],
+        hostname=config["wifi"].get("hostname", wifi.DEFAULT_HOSTNAME),
         status_led=None,
         timeout_seconds=config["wifi"]["timeout_seconds"],
     )
@@ -131,9 +133,42 @@ def handle_printer_status_update():
     PRINTER_STATUS_UPDATE_REQUIRED = False
 
 
+def debug_status():
+    try:
+        network_config = network.ifconfig()
+    except Exception as exc:
+        network_config = ("unavailable: {}".format(exc),)
+
+    return {
+        "Wi-Fi connected": network.is_connected(),
+        "IP address": network_config[0] if network_config else "unavailable",
+        "Awaiting plate clear": PRINTER_AWAITING_PLATE_CLEAR,
+        "Button press pending": PENDING_BUTTON_PRESS,
+        "Chamber light on": CHAMBER_LIGHT_IS_ON,
+        "Status update pending": PRINTER_STATUS_UPDATE_REQUIRED,
+    }
+
+
+try:
+    web_server = web_config.WebConfigServer(
+        config=config,
+        api=api,
+        status_provider=debug_status,
+    )
+    print("Web configuration available at http://{}/".format(network.ifconfig()[0]))
+except Exception as exc:
+    web_server = None
+    print("Web configuration server unavailable:", exc)
+
+
 # -- Main loop --
 while True:
     watchdog.feed()
+
+    if web_server is not None and web_server.poll():
+        print("Configuration updated; restarting")
+        time.sleep_ms(100)
+        machine.reset()
 
     # Push button press to API if pending
     if PENDING_BUTTON_PRESS:

--- a/micro/web_config.py
+++ b/micro/web_config.py
@@ -1,0 +1,500 @@
+import socket
+
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+
+CONFIG_PATH = "config.json"
+DEFAULT_HOSTNAME = "bambutton"
+MAX_REQUEST_BYTES = 8192
+
+
+class WebConfigServer:
+    """Small LAN-only configuration server for the MicroPython board.
+
+    The server is deliberately polled from the main loop instead of running a
+    second thread. That keeps configuration writes and application state in one
+    execution context and avoids adding an AP or any extra runtime service.
+    """
+
+    def __init__(
+        self,
+        config,
+        api,
+        status_provider=None,
+        config_path=CONFIG_PATH,
+        host="0.0.0.0",
+        port=80,
+        socket_module=socket,
+    ):
+        self.config = config
+        self.api = api
+        self.status_provider = status_provider or (lambda: {})
+        self.config_path = config_path
+        self.socket_module = socket_module
+        self.restart_requested = False
+
+        self.listener = socket_module.socket()
+        try:
+            self.listener.setsockopt(
+                socket_module.SOL_SOCKET,
+                socket_module.SO_REUSEADDR,
+                1,
+            )
+        except (AttributeError, OSError):
+            pass
+
+        self.listener.bind((host, port))
+        self.listener.listen(1)
+        self.listener.settimeout(0)
+
+    def close(self):
+        if self.listener is not None:
+            self.listener.close()
+            self.listener = None
+
+    def poll(self):
+        """Handle at most one browser request without blocking the main loop."""
+        if self.listener is None:
+            return False
+
+        client = None
+        try:
+            client, _address = self.listener.accept()
+            client.settimeout(0.25)
+            method, path, body = _read_request(client)
+            status, content_type, response_body = self.handle_request(method, path, body)
+            _send_response(client, status, content_type, response_body)
+        except OSError:
+            # A non-blocking listener reports no pending connection as OSError.
+            # Request-level socket errors are also safe to ignore: the next
+            # browser request can retry without affecting the button loop.
+            pass
+        except Exception as exc:
+            if client is not None:
+                try:
+                    _send_response(
+                        client,
+                        500,
+                        "text/html; charset=utf-8",
+                        _error_page("Web configuration error", str(exc)),
+                    )
+                except OSError:
+                    pass
+        finally:
+            if client is not None:
+                client.close()
+
+        restart_requested = self.restart_requested
+        self.restart_requested = False
+        return restart_requested
+
+    def handle_request(self, method, path, body=""):
+        route = path.split("?", 1)[0]
+
+        if method == "GET" and route in ("/", "/index.html"):
+            message = ""
+            if "saved=1" in path:
+                message = "Settings saved. The board will restart to apply them."
+            return 200, "text/html; charset=utf-8", render_config_page(self.config, message)
+
+        if method == "GET" and route == "/debug":
+            return 200, "text/html; charset=utf-8", render_debug_page(self.config, self.status_provider())
+
+        if method == "GET" and route == "/api/printers":
+            try:
+                printers = self.api.get_printers()
+                return 200, "application/json", _json_dumps(printers)
+            except Exception as exc:
+                return 502, "application/json", _json_dumps({"error": str(exc)})
+
+        if method == "POST" and route == "/save":
+            form = parse_form(body)
+            try:
+                new_config = build_config(form, self.config)
+            except ValueError as exc:
+                return 400, "text/html; charset=utf-8", _error_page("Invalid configuration", str(exc))
+            save_config(self.config_path, new_config)
+            self.config = new_config
+            self.restart_requested = True
+            return 200, "text/html; charset=utf-8", render_config_page(
+                self.config,
+                "Settings saved. The board will restart to apply them.",
+            )
+
+        return 404, "text/html; charset=utf-8", _error_page("Not found", "The requested page does not exist.")
+
+
+def parse_form(body):
+    values = {}
+    if not body:
+        return values
+
+    for item in body.split("&"):
+        if "=" in item:
+            key, value = item.split("=", 1)
+        else:
+            key, value = item, ""
+        values[_url_decode(key)] = _url_decode(value)
+
+    return values
+
+
+def build_config(form, current_config):
+    config = _copy_dict(current_config)
+    wifi = config.setdefault("wifi", {})
+    api = config.setdefault("api", {})
+    printer = config.setdefault("printer", {})
+    led = config.setdefault("led", {})
+    button = config.setdefault("button", {})
+
+    wifi["ssid"] = _required_text(form, "wifi_ssid", wifi.get("ssid", ""), "Wi-Fi SSID")
+    wifi["password"] = _optional_secret(form, "wifi_password", wifi.get("password", ""))
+    wifi["hostname"] = validate_hostname(
+        _required_text(form, "hostname", wifi.get("hostname", DEFAULT_HOSTNAME), "Hostname")
+    )
+
+    api["base_url"] = _required_url(
+        _required_text(form, "api_base_url", api.get("base_url", ""), "API base URL")
+    )
+    api["key"] = _optional_secret(form, "api_key", api.get("key", ""))
+
+    printer_id = _parse_int(
+        _required_text(form, "printer_id", printer.get("id", ""), "Printer"),
+        "Printer",
+    )
+    if printer_id < 1:
+        raise ValueError("Printer must be a positive number.")
+    printer["id"] = printer_id
+
+    led_pin = _parse_pin(
+        _required_text(form, "led_pin", led.get("pin", ""), "LED pin"),
+        "LED pin",
+    )
+    button_pin = _parse_pin(
+        _required_text(form, "button_pin", button.get("pin", ""), "Button pin"),
+        "Button pin",
+    )
+    if led_pin == button_pin:
+        raise ValueError("LED pin and button pin must be different.")
+    led["pin"] = led_pin
+    button["pin"] = button_pin
+
+    return config
+
+
+def save_config(path, config):
+    serialized = _json_dumps(config)
+    with open(path, "w") as config_file:
+        config_file.write(serialized)
+        config_file.write("\n")
+
+
+def render_config_page(config, message=""):
+    wifi = config.get("wifi", {})
+    api = config.get("api", {})
+    printer = config.get("printer", {})
+    led = config.get("led", {})
+    button = config.get("button", {})
+
+    saved_message = ""
+    if message:
+        saved_message = '<p class="message">{}</p>'.format(_escape_html(message))
+
+    content = """
+        <h1>Bambutton configuration</h1>
+        <p>Configure this board over the existing Wi-Fi network. Changes are saved to the board and applied after restart.</p>
+        __SAVED_MESSAGE__
+        <form method="post" action="/save">
+          <fieldset>
+            <legend>Network</legend>
+            <label>Hostname <input name="hostname" value="__HOSTNAME__" required></label>
+            <label>Wi-Fi SSID <input name="wifi_ssid" value="__SSID__" required></label>
+            <label>Wi-Fi password <input type="password" name="wifi_password" placeholder="Leave blank to keep current"></label>
+          </fieldset>
+          <fieldset>
+            <legend>Bambuddy API</legend>
+            <label>Base URL <input name="api_base_url" value="__BASE_URL__" required></label>
+            <label>API key <input type="password" name="api_key" placeholder="Leave blank to keep current"></label>
+            <label>Printer
+              <select id="printer_id" name="printer_id" required>
+                <option value="__PRINTER_ID__">Current printer (__PRINTER_ID__)</option>
+              </select>
+            </label>
+            <button type="button" id="load-printers">Load printers from Bambuddy</button>
+            <span id="printer-status"></span>
+          </fieldset>
+          <fieldset>
+            <legend>Button hardware</legend>
+            <label>LED pin <input name="led_pin" inputmode="numeric" value="__LED_PIN__" required></label>
+            <label>Button pin <input name="button_pin" inputmode="numeric" value="__BUTTON_PIN__" required></label>
+          </fieldset>
+          <button type="submit">Save and restart</button>
+        </form>
+        <p><a href="/debug">Open debug information</a></p>
+        <script>
+          const printerSelect = document.getElementById("printer_id");
+          const printerStatus = document.getElementById("printer-status");
+          document.getElementById("load-printers").addEventListener("click", async () => {
+            printerStatus.textContent = "Loading...";
+            try {
+              const response = await fetch("/api/printers");
+              const data = await response.json();
+              if (!response.ok) throw new Error(data.error || "Bambuddy rejected the request");
+              const printers = Array.isArray(data) ? data : (data.printers || data.results || data.items || []);
+              printerSelect.replaceChildren();
+              printers.forEach((printer) => {
+                if (printer.id === undefined) return;
+                const option = document.createElement("option");
+                option.value = printer.id;
+                option.textContent = (printer.friendly_name || printer.name || printer.display_name || "Printer") + " (" + printer.id + ")";
+                printerSelect.appendChild(option);
+              });
+              if (!printers.length) throw new Error("No printers returned by Bambuddy");
+              printerStatus.textContent = " Loaded.";
+            } catch (error) {
+              printerStatus.textContent = " " + error.message;
+            }
+          });
+        </script>
+        """
+    replacements = {
+        "__SAVED_MESSAGE__": saved_message,
+        "__HOSTNAME__": _escape_html(wifi.get("hostname", DEFAULT_HOSTNAME)),
+        "__SSID__": _escape_html(wifi.get("ssid", "")),
+        "__BASE_URL__": _escape_html(api.get("base_url", "")),
+        "__PRINTER_ID__": _escape_html(printer.get("id", "")),
+        "__LED_PIN__": _escape_html(led.get("pin", "")),
+        "__BUTTON_PIN__": _escape_html(button.get("pin", "")),
+    }
+    for marker, value in replacements.items():
+        content = content.replace(marker, value)
+
+    return _page("Bambutton configuration", content)
+
+
+def render_debug_page(config, status):
+    wifi = config.get("wifi", {})
+    api = config.get("api", {})
+    printer = config.get("printer", {})
+    safe_values = {
+        "Configured hostname": wifi.get("hostname", DEFAULT_HOSTNAME),
+        "Wi-Fi SSID": wifi.get("ssid", ""),
+        "API base URL": api.get("base_url", ""),
+        "Printer ID": printer.get("id", ""),
+        "LED pin": config.get("led", {}).get("pin", ""),
+        "Button pin": config.get("button", {}).get("pin", ""),
+    }
+    if not isinstance(status, dict):
+        status = {"status": status}
+
+    rows = []
+    for label, value in safe_values.items():
+        rows.append("<tr><th>{}</th><td>{}</td></tr>".format(_escape_html(label), _escape_html(value)))
+    for label, value in status.items():
+        rows.append("<tr><th>{}</th><td>{}</td></tr>".format(_escape_html(label), _escape_html(value)))
+
+    return _page(
+        "Bambutton debug information",
+        "<h1>Bambutton debug information</h1><table>{}</table><p><a href=\"/\">Back to configuration</a></p>".format(
+            "".join(rows)
+        ),
+    )
+
+
+def validate_hostname(hostname):
+    if not hostname or len(hostname) > 63:
+        raise ValueError("Hostname must be between 1 and 63 characters.")
+    if not _is_alphanumeric(hostname[0]) or not _is_alphanumeric(hostname[-1]):
+        raise ValueError("Hostname must start and end with a letter or number.")
+    for character in hostname:
+        if not (_is_alphanumeric(character) or character == "-"):
+            raise ValueError("Hostname may contain only letters, numbers, and hyphens.")
+    return hostname
+
+
+def _required_text(form, key, current, label):
+    if key not in form:
+        value = current
+    else:
+        value = form[key].strip()
+    if not value:
+        raise ValueError("{} is required.".format(label))
+    return value
+
+
+def _optional_secret(form, key, current):
+    value = form.get(key)
+    if value is None or value == "":
+        return current
+    return value
+
+
+def _required_url(value):
+    if " " in value or not (value.startswith("http://") or value.startswith("https://")):
+        raise ValueError("API base URL must start with http:// or https:// and contain no spaces.")
+    return value.rstrip("/")
+
+
+def _parse_int(value, label):
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        raise ValueError("{} must be a number.".format(label))
+
+
+def _parse_pin(value, label):
+    pin = _parse_int(value, label)
+    if pin < 0 or pin > 21:
+        raise ValueError("{} must be between 0 and 21.".format(label))
+    return pin
+
+
+def _is_alphanumeric(value):
+    return ("a" <= value <= "z") or ("A" <= value <= "Z") or ("0" <= value <= "9")
+
+
+def _copy_dict(source):
+    result = {}
+    for key, value in source.items():
+        result[key] = _copy_dict(value) if isinstance(value, dict) else value
+    return result
+
+
+def _read_request(client):
+    request = b""
+    while b"\r\n\r\n" not in request:
+        chunk = client.recv(512)
+        if not chunk:
+            break
+        request += chunk
+        if len(request) > MAX_REQUEST_BYTES:
+            raise ValueError("Request is too large")
+
+    header_end = request.find(b"\r\n\r\n")
+    if header_end < 0:
+        raise ValueError("Incomplete HTTP request")
+
+    header_text = request[:header_end].decode("utf-8")
+    lines = header_text.split("\r\n")
+    request_line = lines[0].split(" ")
+    if len(request_line) != 3:
+        raise ValueError("Invalid HTTP request line")
+
+    headers = {}
+    for line in lines[1:]:
+        if ":" in line:
+            key, value = line.split(":", 1)
+            headers[key.lower().strip()] = value.strip()
+
+    try:
+        body_length = int(headers.get("content-length", "0"))
+    except ValueError:
+        raise ValueError("Invalid content length")
+
+    if body_length < 0 or body_length > MAX_REQUEST_BYTES:
+        raise ValueError("Request body is too large")
+
+    body = request[header_end + 4 :]
+    while len(body) < body_length:
+        chunk = client.recv(min(512, body_length - len(body)))
+        if not chunk:
+            break
+        body += chunk
+
+    if len(body) != body_length:
+        raise ValueError("Incomplete HTTP request body")
+
+    return request_line[0], request_line[1], body.decode("utf-8")
+
+
+def _send_response(client, status, content_type, body):
+    status_text = {
+        200: "OK",
+        400: "Bad Request",
+        404: "Not Found",
+        500: "Internal Server Error",
+        502: "Bad Gateway",
+    }.get(status, "Response")
+    payload = body.encode("utf-8") if isinstance(body, str) else body
+    response = (
+        "HTTP/1.1 {} {}\r\n"
+        "Content-Type: {}\r\n"
+        "Content-Length: {}\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+    ).format(status, status_text, content_type, len(payload)).encode("utf-8")
+    _send_all(client, response + payload)
+
+
+def _send_all(client, payload):
+    sent = 0
+    while sent < len(payload):
+        sent += client.send(payload[sent:])
+
+
+def _page(title, content):
+    return """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{}</title>
+  <style>
+    body {{ font: 16px sans-serif; max-width: 760px; margin: 2rem auto; padding: 0 1rem; color: #222; }}
+    fieldset {{ margin: 1rem 0; border: 1px solid #bbb; border-radius: 6px; }}
+    label {{ display: block; margin: .8rem 0; }}
+    input, select {{ box-sizing: border-box; max-width: 100%; padding: .45rem; width: 28rem; }}
+    button {{ padding: .55rem .8rem; margin: .25rem .25rem .25rem 0; }}
+    .message {{ background: #e5f5e5; padding: .8rem; border-radius: 4px; }}
+    #printer-status {{ margin-left: .5rem; }}
+    table {{ border-collapse: collapse; width: 100%; }}
+    th, td {{ border: 1px solid #bbb; padding: .5rem; text-align: left; }}
+  </style>
+</head>
+<body>{}</body>
+</html>""".format(_escape_html(title), content)
+
+
+def _error_page(title, message):
+    return _page(title, "<h1>{}</h1><p>{}</p><p><a href=\"/\">Back to configuration</a></p>".format(
+        _escape_html(title),
+        _escape_html(message),
+    ))
+
+
+def _json_dumps(value):
+    try:
+        return json.dumps(value, indent=2)
+    except TypeError:
+        return json.dumps(value)
+
+
+def _url_decode(value):
+    value = value.replace("+", " ")
+    result = []
+    index = 0
+    while index < len(value):
+        if value[index] == "%" and index + 2 < len(value):
+            try:
+                result.append(chr(int(value[index + 1 : index + 3], 16)))
+                index += 3
+                continue
+            except ValueError:
+                pass
+        result.append(value[index])
+        index += 1
+    return "".join(result)
+
+
+def _escape_html(value):
+    value = str(value)
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#x27;")
+    )

--- a/micro/web_config.py
+++ b/micro/web_config.py
@@ -103,10 +103,13 @@ class WebConfigServer:
         if method == "GET" and route == "/debug":
             return 200, "text/html; charset=utf-8", render_debug_page(self.config, self.status_provider())
 
-        if method == "GET" and route == "/api/printers":
+        if method in ("GET", "POST") and route == "/api/printers":
             try:
-                printers = self.api.get_printers()
+                form = parse_form(body) if method == "POST" else {}
+                printers = self._get_printers(form)
                 return 200, "application/json", _json_dumps(printers)
+            except ValueError as exc:
+                return 400, "application/json", _json_dumps({"error": str(exc)})
             except Exception as exc:
                 return 502, "application/json", _json_dumps({"error": str(exc)})
 
@@ -125,6 +128,19 @@ class WebConfigServer:
             )
 
         return 404, "text/html; charset=utf-8", _error_page("Not found", "The requested page does not exist.")
+
+    def _get_printers(self, form):
+        if not form:
+            return self.api.get_printers()
+
+        api_config = self.config.get("api", {})
+        base_url = _required_url(
+            _required_text(form, "api_base_url", api_config.get("base_url", ""), "API base URL")
+        )
+        api_key = _optional_secret(form, "api_key", api_config.get("key", ""))
+        request_timeout = api_config.get("request_timeout_seconds", 3)
+        api_client = self.api.__class__(api_key, base_url, request_timeout)
+        return api_client.get_printers()
 
 
 def parse_form(body):
@@ -217,7 +233,7 @@ def render_config_page(config, message=""):
           <fieldset>
             <legend>Bambuddy API</legend>
             <label>Base URL <input name="api_base_url" value="__BASE_URL__" required></label>
-            <label>API key <input type="password" name="api_key" placeholder="Leave blank to keep current"></label>
+            <label>API key <input id="api_key" type="password" name="api_key" placeholder="Leave blank to keep current"></label>
             <label>Printer
               <select id="printer_id" name="printer_id" required>
                 <option value="__PRINTER_ID__">Current printer (__PRINTER_ID__)</option>
@@ -240,19 +256,38 @@ def render_config_page(config, message=""):
           document.getElementById("load-printers").addEventListener("click", async () => {
             printerStatus.textContent = "Loading...";
             try {
-              const response = await fetch("/api/printers");
+              const currentPrinterId = String(printerSelect.value);
+              const requestBody = new URLSearchParams();
+              requestBody.set("api_base_url", document.querySelector("[name=api_base_url]").value);
+              const apiKey = document.getElementById("api_key").value;
+              if (apiKey) requestBody.set("api_key", apiKey);
+              const response = await fetch("/api/printers", {
+                method: "POST",
+                headers: {"Content-Type": "application/x-www-form-urlencoded"},
+                body: requestBody,
+              });
               const data = await response.json();
               if (!response.ok) throw new Error(data.error || "Bambuddy rejected the request");
               const printers = Array.isArray(data) ? data : (data.printers || data.results || data.items || []);
+              const validPrinters = printers.filter((printer) => printer.id !== undefined);
+              if (!validPrinters.length) throw new Error("No printers returned by Bambuddy");
               printerSelect.replaceChildren();
-              printers.forEach((printer) => {
-                if (printer.id === undefined) return;
+              let currentPrinterFound = false;
+              validPrinters.forEach((printer) => {
                 const option = document.createElement("option");
                 option.value = printer.id;
+                option.selected = String(printer.id) === currentPrinterId;
+                currentPrinterFound = currentPrinterFound || option.selected;
                 option.textContent = (printer.friendly_name || printer.name || printer.display_name || "Printer") + " (" + printer.id + ")";
                 printerSelect.appendChild(option);
               });
-              if (!printers.length) throw new Error("No printers returned by Bambuddy");
+              if (!currentPrinterFound && currentPrinterId) {
+                const option = document.createElement("option");
+                option.value = currentPrinterId;
+                option.textContent = "Current printer (" + currentPrinterId + ", not returned)";
+                option.selected = true;
+                printerSelect.insertBefore(option, printerSelect.firstChild);
+              }
               printerStatus.textContent = " Loaded.";
             } catch (error) {
               printerStatus.textContent = " " + error.message;
@@ -474,19 +509,19 @@ def _json_dumps(value):
 
 def _url_decode(value):
     value = value.replace("+", " ")
-    result = []
+    result = bytearray()
     index = 0
     while index < len(value):
         if value[index] == "%" and index + 2 < len(value):
             try:
-                result.append(chr(int(value[index + 1 : index + 3], 16)))
+                result.append(int(value[index + 1 : index + 3], 16))
                 index += 3
                 continue
             except ValueError:
                 pass
-        result.append(value[index])
+        result.extend(value[index].encode("utf-8"))
         index += 1
-    return "".join(result)
+    return result.decode("utf-8")
 
 
 def _escape_html(value):

--- a/micro/wifi.py
+++ b/micro/wifi.py
@@ -14,6 +14,7 @@ class WiFi:
         timeout_seconds=10,
         connected_led_value=0,
         failed_led_value=1,
+        hostname=DEFAULT_HOSTNAME,
     ):
         self.ssid = ssid
         self.password = password
@@ -21,11 +22,12 @@ class WiFi:
         self.timeout_seconds = timeout_seconds
         self.connected_led_value = connected_led_value
         self.failed_led_value = failed_led_value
+        self.hostname = hostname or DEFAULT_HOSTNAME
         self.wlan = network.WLAN(network.STA_IF)
 
     def connect(self):
         # Set this before activating the interface so DHCP and mDNS can use it.
-        network.hostname(DEFAULT_HOSTNAME)
+        network.hostname(self.hostname)
         self.wlan.active(True)
         # self.wlan.config(txpower=8.5)
         self.wlan.config(pm=network.WLAN.PM_NONE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ packages = ["src/bambutton"]
 "micro/main.py" = "bambutton/micro/main.py"
 "micro/periodic_timer.py" = "bambutton/micro/periodic_timer.py"
 "micro/wifi.py" = "bambutton/micro/wifi.py"
+"micro/web_config.py" = "bambutton/micro/web_config.py"
 "micro/config_example.json" = "bambutton/micro/config_example.json"
 "firmware" = "bambutton/firmware"
 
@@ -66,5 +67,6 @@ include = [
   "/micro/main.py",
   "/micro/periodic_timer.py",
   "/micro/wifi.py",
+  "/micro/web_config.py",
   "/micro/config_example.json",
 ]

--- a/scripts/build_gui.py
+++ b/scripts/build_gui.py
@@ -19,6 +19,7 @@ MICRO_FILES = [
     "main.py",
     "periodic_timer.py",
     "wifi.py",
+    "web_config.py",
     "config_example.json",
 ]
 

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -31,6 +31,7 @@ DEFAULT_FIRMWARE_DIR = RESOURCE_ROOT / "firmware"
 
 GPIO_MIN = 0
 GPIO_MAX = 21
+DEFAULT_HOSTNAME = "bambutton"
 
 CLEAN_BOARD_CODE = """
 import os
@@ -171,6 +172,10 @@ def build_window(config):
                         sg.Input(str(config["button"]["pin"]), key="-BUTTON_PIN-", size=(8, 1), enable_events=True),
                     ],
                     [
+                        sg.Text("Hostname", size=(16, 1)),
+                        sg.Input(config["wifi"].get("hostname", DEFAULT_HOSTNAME), key="-HOSTNAME-", enable_events=True),
+                    ],
+                    [
                         sg.Text("Wi-Fi SSID", size=(16, 1)),
                         sg.Input(config["wifi"]["ssid"], key="-WIFI_SSID-", enable_events=True),
                     ],
@@ -205,7 +210,7 @@ def build_window(config):
 
 def load_existing_config():
     default = {
-        "wifi": {"ssid": "", "password": "", "timeout_seconds": 10},
+        "wifi": {"ssid": "", "password": "", "hostname": DEFAULT_HOSTNAME, "timeout_seconds": 10},
         "api": {"base_url": "", "key": ""},
         "printer": {"id": 1, "poll_interval_seconds": 3},
         "led": {"pin": 3, "flash_interval_ms": 250},
@@ -277,6 +282,9 @@ def collect_basic_errors(values, require_printer=True, require_firmware=True):
     if not values.get("-WIFI_SSID-", "").strip():
         errors.append("Enter a Wi-Fi SSID.")
 
+    if not valid_hostname(values.get("-HOSTNAME-", "")):
+        errors.append("Enter a hostname containing only letters, numbers, and hyphens.")
+
     return errors
 
 
@@ -329,6 +337,7 @@ def build_config(values, printers_by_label):
         "wifi": {
             "ssid": values["-WIFI_SSID-"].strip(),
             "password": values["-WIFI_PASSWORD-"],
+            "hostname": values["-HOSTNAME-"].strip(),
             "timeout_seconds": 10,
         },
         "api": {
@@ -491,6 +500,13 @@ def valid_host_port(value):
         return False
 
     return re.match(r"^[A-Za-z0-9_.-]+:[0-9]{1,5}$", value.strip()) is not None
+
+
+def valid_hostname(value):
+    if not value:
+        return False
+
+    return re.match(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$", value.strip()) is not None
 
 
 def api_base_url_from_host(host):

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,9 @@
+import runpy
+from pathlib import Path
+
+
+def test_release_gui_includes_all_micro_python_modules():
+    project_root = Path(__file__).parents[1]
+    build_script = runpy.run_path(str(project_root / "scripts" / "build_gui.py"))
+
+    assert "web_config.py" in build_script["MICRO_FILES"]

--- a/tests/test_web_config.py
+++ b/tests/test_web_config.py
@@ -44,6 +44,13 @@ def test_parse_form_decodes_url_encoded_values():
     }
 
 
+def test_parse_form_decodes_utf8_values():
+    assert web_config.parse_form("wifi_ssid=Caf%C3%A9&wifi_password=p%C3%A5ss") == {
+        "wifi_ssid": "Café",
+        "wifi_password": "påss",
+    }
+
+
 def test_build_config_updates_web_fields_and_preserves_other_settings():
     current = base_config()
 
@@ -107,7 +114,7 @@ def test_config_page_contains_form_and_does_not_require_formatting_js():
 
     assert 'action="/save"' in page
     assert 'name="hostname"' in page
-    assert 'fetch("/api/printers")' in page
+    assert 'fetch("/api/printers", {' in page
     assert "__HOSTNAME__" not in page
 
 
@@ -138,3 +145,39 @@ def test_save_request_sets_restart_flag_and_returns_updated_page(tmp_path):
     assert server.restart_requested is True
     assert "shop-button" in page
     assert json.loads((tmp_path / "config.json").read_text())["printer"]["id"] == 7
+
+
+def test_printer_discovery_uses_submitted_api_settings():
+    calls = []
+
+    class FakeAPI:
+        def __init__(self, api_key, base_url, request_timeout_seconds):
+            calls.append((api_key, base_url, request_timeout_seconds))
+
+        def get_printers(self):
+            return [{"id": 7, "friendly_name": "New API printer"}]
+
+    server = object.__new__(web_config.WebConfigServer)
+    server.config = base_config()
+    server.api = FakeAPI("old-key", "http://old-host:8000/api/v1", 3)
+    server.status_provider = lambda: {}
+    server.restart_requested = False
+
+    status, content_type, body = server.handle_request(
+        "POST",
+        "/api/printers",
+        "api_base_url=http%3A%2F%2Fnew-host%3A8000%2Fapi%2Fv1&api_key=new-key",
+    )
+
+    assert status == 200
+    assert content_type == "application/json"
+    assert "New API printer" in body
+    assert calls[-1] == ("new-key", "http://new-host:8000/api/v1", 3)
+
+
+def test_config_page_preserves_printer_selection_when_loading_printers():
+    page = web_config.render_config_page(base_config())
+
+    assert 'const currentPrinterId = String(printerSelect.value);' in page
+    assert 'option.selected = String(printer.id) === currentPrinterId;' in page
+    assert 'Current printer (" + currentPrinterId + ", not returned)' in page

--- a/tests/test_web_config.py
+++ b/tests/test_web_config.py
@@ -1,0 +1,140 @@
+import json
+
+import pytest
+
+from micro import web_config
+
+
+def base_config():
+    return {
+        "wifi": {
+            "ssid": "old-network",
+            "password": "old-password",
+            "hostname": "bambutton",
+            "timeout_seconds": 10,
+        },
+        "api": {
+            "base_url": "http://old-host:8000/api/v1",
+            "key": "old-key",
+            "request_timeout_seconds": 3,
+        },
+        "printer": {"id": 1, "poll_interval_seconds": 3},
+        "led": {"pin": 3, "flash_interval_ms": 250},
+        "button": {"pin": 4, "debounce_ms": 150, "pull": "down", "trigger": "rising"},
+    }
+
+
+def valid_form():
+    return {
+        "hostname": "shop-button",
+        "wifi_ssid": "new network",
+        "wifi_password": "new-password",
+        "api_base_url": "http://new-host:8000/api/v1/",
+        "api_key": "new-key",
+        "printer_id": "7",
+        "led_pin": "5",
+        "button_pin": "6",
+    }
+
+
+def test_parse_form_decodes_url_encoded_values():
+    assert web_config.parse_form("wifi_ssid=shop+wifi&api_key=a%2Bb") == {
+        "wifi_ssid": "shop wifi",
+        "api_key": "a+b",
+    }
+
+
+def test_build_config_updates_web_fields_and_preserves_other_settings():
+    current = base_config()
+
+    updated = web_config.build_config(valid_form(), current)
+
+    assert updated["wifi"] == {
+        "ssid": "new network",
+        "password": "new-password",
+        "hostname": "shop-button",
+        "timeout_seconds": 10,
+    }
+    assert updated["api"]["base_url"] == "http://new-host:8000/api/v1"
+    assert updated["api"]["key"] == "new-key"
+    assert updated["printer"]["id"] == 7
+    assert updated["led"]["pin"] == 5
+    assert updated["button"]["pin"] == 6
+    assert current["printer"]["id"] == 1
+    assert current["api"]["base_url"] == "http://old-host:8000/api/v1"
+
+
+def test_blank_secrets_keep_existing_values():
+    current = base_config()
+    form = valid_form()
+    form["wifi_password"] = ""
+    form["api_key"] = ""
+
+    updated = web_config.build_config(form, current)
+
+    assert updated["wifi"]["password"] == "old-password"
+    assert updated["api"]["key"] == "old-key"
+
+
+@pytest.mark.parametrize(
+    "field,value,error",
+    [
+        ("hostname", "bad name", "Hostname may contain only letters, numbers, and hyphens."),
+        ("api_base_url", "new-host:8000", "API base URL must start with http:// or https:// and contain no spaces."),
+        ("led_pin", "22", "LED pin must be between 0 and 21."),
+        ("button_pin", "5", "LED pin and button pin must be different."),
+    ],
+)
+def test_build_config_rejects_invalid_values(field, value, error):
+    form = valid_form()
+    form[field] = value
+
+    with pytest.raises(ValueError, match=error):
+        web_config.build_config(form, base_config())
+
+
+def test_save_config_writes_json(tmp_path):
+    path = tmp_path / "config.json"
+    config = base_config()
+
+    web_config.save_config(str(path), config)
+
+    assert json.loads(path.read_text()) == config
+
+
+def test_config_page_contains_form_and_does_not_require_formatting_js():
+    page = web_config.render_config_page(base_config())
+
+    assert 'action="/save"' in page
+    assert 'name="hostname"' in page
+    assert 'fetch("/api/printers")' in page
+    assert "__HOSTNAME__" not in page
+
+
+def test_debug_page_does_not_expose_secrets():
+    page = web_config.render_debug_page(base_config(), {"IP address": "192.168.1.20"})
+
+    assert "old-password" not in page
+    assert "old-key" not in page
+    assert "192.168.1.20" in page
+
+
+def test_save_request_sets_restart_flag_and_returns_updated_page(tmp_path):
+    server = object.__new__(web_config.WebConfigServer)
+    server.config = base_config()
+    server.api = None
+    server.status_provider = lambda: {}
+    server.config_path = str(tmp_path / "config.json")
+    server.restart_requested = False
+
+    status, content_type, page = server.handle_request(
+        "POST",
+        "/save",
+        "&".join("{}={}".format(key, value) for key, value in valid_form().items()),
+    )
+
+    assert status == 200
+    assert content_type.startswith("text/html")
+    assert server.restart_requested is True
+    assert "shop-button" in page
+    assert json.loads((tmp_path / "config.json").read_text())["printer"]["id"] == 7

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -71,3 +71,12 @@ def test_connect_disables_wifi_power_management(monkeypatch):
     wlan = wifi.connect()
 
     assert wlan.config_calls == [{"pm": "pm-none"}]
+
+
+def test_connect_uses_configured_hostname(monkeypatch):
+    events = []
+    wifi_module = load_wifi_module(monkeypatch, events)
+
+    wifi_module.WiFi("ssid", "password", hostname="shop-button").connect()
+
+    assert events[0] == ("hostname", "shop-button")


### PR DESCRIPTION
Fixes #11

Adds a station-mode MicroPython HTTP configuration page on port 80 for hostname, Wi-Fi, Bambuddy API, printer, LED pin, and button pin settings; loads printer choices through the currently entered API settings; preserves the selected printer; persists validated settings, restarts after save, and exposes non-secret debug state. Release GUI packaging includes web_config.py, and form decoding handles UTF-8 values. No access-point mode is added.

Security note: the station-mode web configuration has no authentication, login, token, session, or request-origin/CSRF protection. It is intended to be reachable only on the existing trusted LAN; this limitation is explicitly accepted for this PR.

Validation: 18 focused tests passed; Python compilation, git diff --check, packaging-manifest coverage, and critical Ruff checks passed. Full GUI test collection still requires the missing pyserial dependency; hardware validation was not run.