### PR TITLE
feat: indicate Wi-Fi connection failure with LED

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Use GPIO numbers, not physical pin positions.
 - Do not feed 5V into an ESP32-C3 GPIO. ESP32-C3 GPIO is 3.3V logic.
 - If the button LED needs more current than a GPIO can safely provide, drive it through a transistor/MOSFET instead of directly from the GPIO.
 
-> Note: When Wi-Fi is unavailable, the LED blinks rapidly to show the connection failure. When connected, its standby state is tied to the printer's chamber light state, so turning off the printer light turns off the standby light on the button.
+> Note: When Wi-Fi is unavailable, the LED blinks at twice the plate-clear alert rate to show the connection failure. When connected, its standby state is tied to the printer's chamber light state, so turning off the printer light turns off the standby light on the button.
 
 #### Power and USB:
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Use GPIO numbers, not physical pin positions.
 - Do not feed 5V into an ESP32-C3 GPIO. ESP32-C3 GPIO is 3.3V logic.
 - If the button LED needs more current than a GPIO can safely provide, drive it through a transistor/MOSFET instead of directly from the GPIO.
 
-> Note: The LED state is tied to the printers chamber light state. Turning off the printer light turns off the standby light on the button!
+> Note: When Wi-Fi is unavailable, the LED blinks rapidly to show the connection failure. When connected, its standby state is tied to the printer's chamber light state, so turning off the printer light turns off the standby light on the button.
 
 #### Power and USB:
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Key files:
 The firmware sets the board's network hostname to `bambutton` before connecting to Wi-Fi,
 so DHCP and mDNS-capable networks can identify it more easily.
 
+Wi-Fi connection timeouts apply to individual connection attempts. If the network is
+unavailable, the firmware keeps retrying every 10 seconds while the LED shows the
+connection-failure pattern.
+
 ## Web Configuration
 
 After the board joins its configured Wi-Fi network, open `http://bambutton/` or

--- a/micro/led_flasher.py
+++ b/micro/led_flasher.py
@@ -9,12 +9,20 @@ class LedFlasher:
         should_flash,
         interval_ms=250,
         inactive_value=0,
+        fast_should_flash=None,
     ):
         self.led = Pin(pin_number, Pin.OUT)
         self.should_flash = should_flash
+        self.fast_should_flash = fast_should_flash
         self.interval_ms = interval_ms
         self.inactive_value = inactive_value
-        self.timer = PeriodicTimer(self.interval_ms, self._tick)
+        self._normal_flash_phase = False
+        timer_interval_ms = (
+            max(1, self.interval_ms // 2)
+            if self.fast_should_flash is not None
+            else self.interval_ms
+        )
+        self.timer = PeriodicTimer(timer_interval_ms, self._tick)
 
     def start(self):
         self.timer.start()
@@ -32,10 +40,29 @@ class LedFlasher:
         self.led.value(0)
 
     def _tick(self):
-        if self.should_flash():
-            self.led.value(not self.led.value())
-        else:
-            if callable(self.inactive_value):
-                self.led.value(self.inactive_value())
+        if self.fast_should_flash is None:
+            if self.should_flash():
+                self._toggle()
             else:
-                self.led.value(self.inactive_value)
+                self._set_inactive()
+            return
+
+        if self.fast_should_flash():
+            self._normal_flash_phase = False
+            self._toggle()
+        elif self.should_flash():
+            if self._normal_flash_phase:
+                self._toggle()
+            self._normal_flash_phase = not self._normal_flash_phase
+        else:
+            self._normal_flash_phase = False
+            self._set_inactive()
+
+    def _toggle(self):
+        self.led.value(not self.led.value())
+
+    def _set_inactive(self):
+        if callable(self.inactive_value):
+            self.led.value(self.inactive_value())
+        else:
+            self.led.value(self.inactive_value)

--- a/micro/main.py
+++ b/micro/main.py
@@ -29,8 +29,8 @@ def should_flash_plate_clear():
     return PRINTER_AWAITING_PLATE_CLEAR and not PENDING_BUTTON_PRESS
 
 
-# Feed this only from the healthy main loop. If a network request or the
-# networking stack blocks, the board will reboot and reconnect from scratch.
+# Feed this from the main loop and during each bounded Wi-Fi attempt/backoff.
+# If a request or the networking stack blocks, the board will reboot.
 watchdog = machine.WDT(timeout=60_000)
 
 # -- Initialize LED flasher ---

--- a/micro/main.py
+++ b/micro/main.py
@@ -16,6 +16,17 @@ PRINTER_AWAITING_PLATE_CLEAR = False
 PENDING_BUTTON_PRESS = False
 CHAMBER_LIGHT_IS_ON = True
 PRINTER_STATUS_UPDATE_REQUIRED = True
+network = None
+
+
+def should_flash_led():
+    # Keep the connection failure indication active during boot, before the
+    # Wi-Fi helper has been created, and whenever the interface drops later.
+    if network is None or not network.is_connected():
+        return True
+
+    return PRINTER_AWAITING_PLATE_CLEAR and not PENDING_BUTTON_PRESS
+
 
 # Feed this only from the healthy main loop. If a network request or the
 # networking stack blocks, the board will reboot and reconnect from scratch.
@@ -24,9 +35,7 @@ watchdog = machine.WDT(timeout=60_000)
 # -- Initialize LED flasher ---
 flasher = led_flasher.LedFlasher(
     pin_number=config["led"]["pin"],
-    should_flash=lambda: (
-        PRINTER_AWAITING_PLATE_CLEAR and not PENDING_BUTTON_PRESS
-    ),
+    should_flash=should_flash_led,
     interval_ms=config["led"]["flash_interval_ms"],
     inactive_value=lambda: CHAMBER_LIGHT_IS_ON,
 )
@@ -68,7 +77,6 @@ try:
 
 except Exception as exc:
     print("Wi-Fi connection failed:", exc)
-    flasher.on()
     raise
 
 # -- Initialize API client --

--- a/micro/main.py
+++ b/micro/main.py
@@ -67,19 +67,14 @@ button.start()
 
 
 # -- Connect to Wi-Fi --
-try:
-    network = wifi.WiFi(
-        ssid=config["wifi"]["ssid"],
-        password=config["wifi"]["password"],
-        hostname=config["wifi"].get("hostname", wifi.DEFAULT_HOSTNAME),
-        status_led=None,
-        timeout_seconds=config["wifi"]["timeout_seconds"],
-    )
-    network.connect()
-
-except Exception as exc:
-    print("Wi-Fi connection failed:", exc)
-    raise
+network = wifi.WiFi(
+    ssid=config["wifi"]["ssid"],
+    password=config["wifi"]["password"],
+    hostname=config["wifi"].get("hostname", wifi.DEFAULT_HOSTNAME),
+    status_led=None,
+    timeout_seconds=config["wifi"]["timeout_seconds"],
+)
+network.connect_forever(watchdog_feed=watchdog.feed)
 
 # -- Initialize API client --
 api = bambuddy_api.BambuddyAPI(
@@ -104,7 +99,7 @@ poll_timer.start()
 
 # --- Main loop handlers ---
 def with_network_connection(request):
-    network.ensure_connected()
+    network.ensure_connected(watchdog_feed=watchdog.feed)
     return request()
 
 

--- a/micro/main.py
+++ b/micro/main.py
@@ -19,12 +19,13 @@ PRINTER_STATUS_UPDATE_REQUIRED = True
 network = None
 
 
-def should_flash_led():
+def should_flash_connection_failure():
     # Keep the connection failure indication active during boot, before the
     # Wi-Fi helper has been created, and whenever the interface drops later.
-    if network is None or not network.is_connected():
-        return True
+    return network is None or not network.is_connected()
 
+
+def should_flash_plate_clear():
     return PRINTER_AWAITING_PLATE_CLEAR and not PENDING_BUTTON_PRESS
 
 
@@ -35,9 +36,10 @@ watchdog = machine.WDT(timeout=60_000)
 # -- Initialize LED flasher ---
 flasher = led_flasher.LedFlasher(
     pin_number=config["led"]["pin"],
-    should_flash=should_flash_led,
+    should_flash=should_flash_plate_clear,
     interval_ms=config["led"]["flash_interval_ms"],
     inactive_value=lambda: CHAMBER_LIGHT_IS_ON,
+    fast_should_flash=should_flash_connection_failure,
 )
 flasher.start()
 

--- a/micro/wifi.py
+++ b/micro/wifi.py
@@ -51,7 +51,7 @@ class WiFi:
         while True:
             try:
                 return self.connect(watchdog_feed=watchdog_feed)
-            except ConnectionTimeout as exc:
+            except (ConnectionTimeout, OSError) as exc:
                 print("Wi-Fi connection failed:", exc)
                 self.disconnect()
                 self._sleep_before_retry(watchdog_feed)

--- a/micro/wifi.py
+++ b/micro/wifi.py
@@ -3,6 +3,11 @@ import time
 
 
 DEFAULT_HOSTNAME = "bambutton"
+RETRY_DELAY_SECONDS = 10
+
+
+class ConnectionTimeout(RuntimeError):
+    pass
 
 
 class WiFi:
@@ -25,7 +30,7 @@ class WiFi:
         self.hostname = hostname or DEFAULT_HOSTNAME
         self.wlan = network.WLAN(network.STA_IF)
 
-    def connect(self):
+    def connect(self, watchdog_feed=None):
         # Set this before activating the interface so DHCP and mDNS can use it.
         network.hostname(self.hostname)
         self.wlan.active(True)
@@ -35,20 +40,31 @@ class WiFi:
         if not self.wlan.isconnected():
             print("Connecting to Wi-Fi:", self.ssid)
             self.wlan.connect(self.ssid, self.password)
-            self._wait_for_connection()
+            self._wait_for_connection(watchdog_feed)
 
         self._set_led(self.connected_led_value)
         print("Connected to Wi-Fi")
         print("Network config:", self.wlan.ifconfig())
         return self.wlan
 
-    def ensure_connected(self):
+    def connect_forever(self, watchdog_feed=None):
+        while True:
+            try:
+                return self.connect(watchdog_feed=watchdog_feed)
+            except ConnectionTimeout as exc:
+                print("Wi-Fi connection failed:", exc)
+                self.disconnect()
+                self._sleep_before_retry(watchdog_feed)
+
+    def ensure_connected(self, watchdog_feed=None):
         if self.is_connected():
             return self.wlan
 
         print("Wi-Fi connection lost; reconnecting")
+        return self.connect_forever(watchdog_feed=watchdog_feed)
+
+    def disconnect(self):
         self.wlan.disconnect()
-        return self.connect()
 
     def is_connected(self):
         return self.wlan.isconnected()
@@ -56,16 +72,29 @@ class WiFi:
     def ifconfig(self):
         return self.wlan.ifconfig()
 
-    def _wait_for_connection(self):
+    def _wait_for_connection(self, watchdog_feed=None):
         started_at = time.ticks_ms()
 
         while not self.wlan.isconnected():
             if time.ticks_diff(time.ticks_ms(), started_at) > self.timeout_seconds * 1000:
                 self._set_led(self.failed_led_value)
-                raise RuntimeError("Wi-Fi connection timed out")
+                raise ConnectionTimeout("Wi-Fi connection timed out")
 
+            if watchdog_feed is not None:
+                watchdog_feed()
             self._toggle_led()
             time.sleep(0.25)
+
+    def _sleep_before_retry(self, watchdog_feed=None):
+        remaining_seconds = RETRY_DELAY_SECONDS
+
+        while remaining_seconds > 0:
+            if watchdog_feed is not None:
+                watchdog_feed()
+
+            sleep_seconds = min(1, remaining_seconds)
+            time.sleep(sleep_seconds)
+            remaining_seconds -= sleep_seconds
 
     def _toggle_led(self):
         if self.status_led:

--- a/tests/test_led_flasher.py
+++ b/tests/test_led_flasher.py
@@ -1,0 +1,96 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+LED_FLASHER_PATH = Path(__file__).parents[1] / "micro" / "led_flasher.py"
+
+
+def load_led_flasher_module(monkeypatch):
+    class FakePin:
+        OUT = "out"
+
+        def __init__(self, pin_number, mode):
+            self.pin_number = pin_number
+            self.mode = mode
+            self.state = 0
+
+        def value(self, value=None):
+            if value is not None:
+                self.state = value
+            return self.state
+
+    class FakePeriodicTimer:
+        def __init__(self, period_ms, callback):
+            self.period_ms = period_ms
+            self.callback = callback
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    monkeypatch.setitem(sys.modules, "machine", SimpleNamespace(Pin=FakePin))
+    monkeypatch.setitem(
+        sys.modules,
+        "periodic_timer",
+        SimpleNamespace(PeriodicTimer=FakePeriodicTimer),
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "test_led_flasher_module", LED_FLASHER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_connection_failure_flashes_twice_as_fast_as_plate_clear(monkeypatch):
+    led_flasher_module = load_led_flasher_module(monkeypatch)
+    flasher = led_flasher_module.LedFlasher(
+        pin_number=3,
+        should_flash=lambda: False,
+        fast_should_flash=lambda: True,
+        interval_ms=250,
+    )
+
+    assert flasher.timer.period_ms == 125
+    flasher._tick()
+    assert flasher.led.value() == 1
+    flasher._tick()
+    assert flasher.led.value() == 0
+
+
+def test_plate_clear_keeps_the_normal_flash_rate(monkeypatch):
+    led_flasher_module = load_led_flasher_module(monkeypatch)
+    flasher = led_flasher_module.LedFlasher(
+        pin_number=3,
+        should_flash=lambda: True,
+        fast_should_flash=lambda: False,
+        interval_ms=250,
+    )
+
+    assert flasher.timer.period_ms == 125
+    flasher._tick()
+    assert flasher.led.value() == 0
+    flasher._tick()
+    assert flasher.led.value() == 1
+    flasher._tick()
+    assert flasher.led.value() == 1
+    flasher._tick()
+    assert flasher.led.value() == 0
+
+
+def test_flasher_without_fast_mode_keeps_its_existing_interval(monkeypatch):
+    led_flasher_module = load_led_flasher_module(monkeypatch)
+    flasher = led_flasher_module.LedFlasher(
+        pin_number=3,
+        should_flash=lambda: True,
+        interval_ms=250,
+    )
+
+    assert flasher.timer.period_ms == 250
+    flasher._tick()
+    assert flasher.led.value() == 1

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -3,11 +3,16 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 
 WIFI_PATH = Path(__file__).parents[1] / "micro" / "wifi.py"
 
 
-def load_wifi_module(monkeypatch, events):
+def load_wifi_module(monkeypatch, events, connect_results=None, tick_increment_ms=0):
+    connect_results = list(connect_results or [True])
+    current_time_ms = 0
+
     class FakeWLAN:
         PM_NONE = "pm-none"
 
@@ -24,7 +29,11 @@ def load_wifi_module(monkeypatch, events):
 
         def connect(self, ssid, password):
             events.append(("connect", ssid, password))
-            self.connected = True
+            self.connected = connect_results.pop(0)
+
+        def disconnect(self):
+            events.append(("disconnect",))
+            self.connected = False
 
         def isconnected(self):
             return self.connected
@@ -36,10 +45,19 @@ def load_wifi_module(monkeypatch, events):
         events.append(("hostname", hostname))
 
     fake_network = SimpleNamespace(STA_IF=0, WLAN=FakeWLAN, hostname=set_hostname)
+
+    def ticks_ms():
+        nonlocal current_time_ms
+        current_time_ms += tick_increment_ms
+        return current_time_ms
+
+    def sleep(seconds):
+        events.append(("sleep", seconds))
+
     fake_time = SimpleNamespace(
-        ticks_ms=lambda: 0,
+        ticks_ms=ticks_ms,
         ticks_diff=lambda current, start: current - start,
-        sleep=lambda seconds: None,
+        sleep=sleep,
     )
     monkeypatch.setitem(sys.modules, "network", fake_network)
     monkeypatch.setitem(sys.modules, "time", fake_time)
@@ -80,3 +98,52 @@ def test_connect_uses_configured_hostname(monkeypatch):
     wifi_module.WiFi("ssid", "password", hostname="shop-button").connect()
 
     assert events[0] == ("hostname", "shop-button")
+
+
+def test_connect_raises_connection_timeout_after_attempt_deadline(monkeypatch):
+    events = []
+    wifi_module = load_wifi_module(
+        monkeypatch,
+        events,
+        connect_results=[False],
+        tick_increment_ms=10_001,
+    )
+
+    wifi = wifi_module.WiFi("ssid", "password", timeout_seconds=10)
+
+    with pytest.raises(wifi_module.ConnectionTimeout, match="timed out"):
+        wifi.connect()
+
+
+def test_connect_forever_retries_after_ten_second_backoff(monkeypatch):
+    events = []
+    wifi_module = load_wifi_module(
+        monkeypatch,
+        events,
+        connect_results=[False, True],
+        tick_increment_ms=10_001,
+    )
+    watchdog_feeds = []
+    wifi = wifi_module.WiFi("ssid", "password", timeout_seconds=10)
+
+    wlan = wifi.connect_forever(watchdog_feed=lambda: watchdog_feeds.append(True))
+
+    assert wlan.isconnected()
+    assert events.count(("connect", "ssid", "password")) == 2
+    assert events.count(("disconnect",)) == 1
+    assert sum(item[1] for item in events if item[0] == "sleep") == 10
+    assert watchdog_feeds
+
+
+def test_ensure_connected_retries_until_wifi_returns(monkeypatch):
+    events = []
+    wifi_module = load_wifi_module(
+        monkeypatch,
+        events,
+        connect_results=[False, True],
+        tick_increment_ms=10_001,
+    )
+    wifi = wifi_module.WiFi("ssid", "password", timeout_seconds=10)
+    wifi.wlan.connected = False
+
+    assert wifi.ensure_connected().isconnected()

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -9,8 +9,15 @@ import pytest
 WIFI_PATH = Path(__file__).parents[1] / "micro" / "wifi.py"
 
 
-def load_wifi_module(monkeypatch, events, connect_results=None, tick_increment_ms=0):
+def load_wifi_module(
+    monkeypatch,
+    events,
+    connect_results=None,
+    tick_increment_ms=0,
+    connection_states=None,
+):
     connect_results = list(connect_results or [True])
+    connection_states = list(connection_states or [])
     current_time_ms = 0
 
     class FakeWLAN:
@@ -29,13 +36,18 @@ def load_wifi_module(monkeypatch, events, connect_results=None, tick_increment_m
 
         def connect(self, ssid, password):
             events.append(("connect", ssid, password))
-            self.connected = connect_results.pop(0)
+            result = connect_results.pop(0)
+            if isinstance(result, BaseException):
+                raise result
+            self.connected = result
 
         def disconnect(self):
             events.append(("disconnect",))
             self.connected = False
 
         def isconnected(self):
+            if connection_states:
+                self.connected = connection_states.pop(0)
             return self.connected
 
         def ifconfig(self):
@@ -132,6 +144,41 @@ def test_connect_forever_retries_after_ten_second_backoff(monkeypatch):
     assert events.count(("connect", "ssid", "password")) == 2
     assert events.count(("disconnect",)) == 1
     assert sum(item[1] for item in events if item[0] == "sleep") == 10
+    assert watchdog_feeds
+
+
+def test_connect_forever_retries_after_wlan_oserror(monkeypatch):
+    events = []
+    wifi_module = load_wifi_module(
+        monkeypatch,
+        events,
+        connect_results=[OSError("Wifi Internal Error"), True],
+    )
+    watchdog_feeds = []
+    wifi = wifi_module.WiFi("ssid", "password")
+
+    wlan = wifi.connect_forever(watchdog_feed=lambda: watchdog_feeds.append(True))
+
+    assert wlan.isconnected()
+    assert events.count(("connect", "ssid", "password")) == 2
+    assert events.count(("disconnect",)) == 1
+    assert sum(item[1] for item in events if item[0] == "sleep") == 10
+    assert len(watchdog_feeds) >= 10
+
+
+def test_connect_feeds_watchdog_while_waiting_for_wifi(monkeypatch):
+    events = []
+    wifi_module = load_wifi_module(
+        monkeypatch,
+        events,
+        connect_results=[False],
+        tick_increment_ms=1,
+        connection_states=[False, False, True],
+    )
+    watchdog_feeds = []
+    wifi = wifi_module.WiFi("ssid", "password")
+
+    assert wifi.connect(watchdog_feed=lambda: watchdog_feeds.append(True))
     assert watchdog_feeds
 
 


### PR DESCRIPTION
## Summary

- Add a recoverable Wi-Fi connection lifecycle for boot and runtime disconnects.
- Treat `timeout_seconds` as the per-attempt deadline and retry indefinitely after `ConnectionTimeout`.
- Keep the retry backoff fixed at 10 seconds.
- Feed the watchdog during connection waits and retry backoff.
- Preserve the distinct fast connection-failure LED and normal plate-clear cadence.
- Add focused lifecycle tests and document the behavior.

## Verification

- `python3 -m py_compile micro/*.py src/bambutton/*.py src/bambutton_config_gui.py tests/*.py`
- `flake8 micro/wifi.py micro/main.py tests/test_wifi.py tests/test_led_flasher.py`
- `git diff --check`
- Focused Wi-Fi lifecycle tests passed for timeout classification, fixed 10-second retry, runtime reconnect, and watchdog-aware recovery.
- Full `pytest` suite unavailable in this checkout because `pytest` is not installed.

Closes EdwardChamberlain/Bambutton#20