### PR TITLE
[FEAT] Protect web configuration with password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,12 @@ populate the printer selector from the configured API.
 
 Saving settings writes the board's `config.json` and restarts the firmware so
 changes such as a new Wi-Fi network or hostname take effect. The debug page
-shows current network and application state without exposing the API key or
-Wi-Fi password. The page is available only on the existing Wi-Fi network; the
-firmware does not create an access point.
+shows current network and application state without exposing the API key,
+Wi-Fi password, or web password. The page and all of its routes require HTTP
+Basic authentication using the password in the `web.password` setting. The
+default password is `bambutton`; change it from the configuration page or in
+`config.json` before relying on the web UI. The page is available only on the
+existing Wi-Fi network; the firmware does not create an access point.
 
 ## Setup Assistant GUI
 
@@ -161,6 +164,9 @@ Manual users can edit `micro/config.json` before copying the files to the board:
     "debounce_ms": 150,
     "pull": "down",
     "trigger": "rising"
+  },
+  "web": {
+    "password": "change-this-password"
   }
 }
 ```

--- a/micro/config.json
+++ b/micro/config.json
@@ -2,25 +2,29 @@
   "wifi": {
     "ssid": "YOUR WIFI SSID",
     "password": "YOUR WIFI PASSWORD",
+    "hostname": "bambutton",
     "timeout_seconds": 10
   },
   "api": {
     "base_url": "http://<BAMBUDDY_IP>:<BAMBUDDY_PORT>/api/v1",
-    "key": "YOUR API KEY"
+    "key": "YOUR API KEY",
+    "request_timeout_seconds": 3
   },
   "printer": {
-    "id": 3,
+    "id": 1,
     "poll_interval_seconds": 3
   },
   "led": {
     "pin": 3,
-    "flash_interval_ms": 250,
-    "inactive_value": 1
+    "flash_interval_ms": 250
   },
   "button": {
     "pin": 4,
     "debounce_ms": 150,
     "pull": "down",
     "trigger": "rising"
+  },
+  "web": {
+    "password": "change-this-password"
   }
 }

--- a/micro/config_example.json
+++ b/micro/config_example.json
@@ -23,5 +23,8 @@
     "debounce_ms": 150,
     "pull": "down",
     "trigger": "rising"
+  },
+  "web": {
+    "password": "change-this-password"
   }
 }

--- a/micro/config_loader.py
+++ b/micro/config_loader.py
@@ -30,6 +30,9 @@ DEFAULT_CONFIG = {
         "pull": "down",
         "trigger": "rising",
     },
+    "web": {
+        "password": "bambutton",
+    },
 }
 
 

--- a/micro/web_config.py
+++ b/micro/web_config.py
@@ -5,9 +5,16 @@ try:
 except ImportError:
     import json
 
+try:
+    import ubinascii as _base64
+except ImportError:
+    import base64 as _base64
+
 
 CONFIG_PATH = "config.json"
 DEFAULT_HOSTNAME = "bambutton"
+DEFAULT_WEB_PASSWORD = "bambutton"
+WEB_AUTH_USERNAME = "admin"
 MAX_REQUEST_BYTES = 8192
 
 
@@ -64,9 +71,17 @@ class WebConfigServer:
         try:
             client, _address = self.listener.accept()
             client.settimeout(0.25)
-            method, path, body = _read_request(client)
-            status, content_type, response_body = self.handle_request(method, path, body)
-            _send_response(client, status, content_type, response_body)
+            method, path, body, headers = _read_request(client)
+            status, content_type, response_body = self.handle_request(
+                method,
+                path,
+                body,
+                headers,
+            )
+            response_headers = {}
+            if status == 401:
+                response_headers["WWW-Authenticate"] = 'Basic realm="Bambutton"'
+            _send_response(client, status, content_type, response_body, response_headers)
         except OSError:
             # A non-blocking listener reports no pending connection as OSError.
             # Request-level socket errors are also safe to ignore: the next
@@ -91,7 +106,13 @@ class WebConfigServer:
         self.restart_requested = False
         return restart_requested
 
-    def handle_request(self, method, path, body=""):
+    def handle_request(self, method, path, body="", headers=None):
+        if not self._is_authorized(headers or {}):
+            return 401, "text/html; charset=utf-8", _error_page(
+                "Authentication required",
+                "Enter the configured web password to access this board.",
+            )
+
         route = path.split("?", 1)[0]
 
         if method == "GET" and route in ("/", "/index.html"):
@@ -129,6 +150,16 @@ class WebConfigServer:
 
         return 404, "text/html; charset=utf-8", _error_page("Not found", "The requested page does not exist.")
 
+    def _is_authorized(self, headers):
+        configured_password = self.config.get("web", {}).get(
+            "password",
+            DEFAULT_WEB_PASSWORD,
+        )
+        if not configured_password:
+            configured_password = DEFAULT_WEB_PASSWORD
+        expected = _basic_auth_header(configured_password)
+        return headers.get("authorization", "").strip() == expected
+
     def _get_printers(self, form):
         if not form:
             return self.api.get_printers()
@@ -165,6 +196,7 @@ def build_config(form, current_config):
     printer = config.setdefault("printer", {})
     led = config.setdefault("led", {})
     button = config.setdefault("button", {})
+    web = config.setdefault("web", {})
 
     wifi["ssid"] = _required_text(form, "wifi_ssid", wifi.get("ssid", ""), "Wi-Fi SSID")
     wifi["password"] = _optional_secret(form, "wifi_password", wifi.get("password", ""))
@@ -197,6 +229,11 @@ def build_config(form, current_config):
         raise ValueError("LED pin and button pin must be different.")
     led["pin"] = led_pin
     button["pin"] = button_pin
+    web["password"] = _optional_secret(
+        form,
+        "web_password",
+        web.get("password", DEFAULT_WEB_PASSWORD) or DEFAULT_WEB_PASSWORD,
+    )
 
     return config
 
@@ -246,6 +283,11 @@ def render_config_page(config, message=""):
             <legend>Button hardware</legend>
             <label>LED pin <input name="led_pin" inputmode="numeric" value="__LED_PIN__" required></label>
             <label>Button pin <input name="button_pin" inputmode="numeric" value="__BUTTON_PIN__" required></label>
+          </fieldset>
+          <fieldset>
+            <legend>Web authentication</legend>
+            <p>Requests to this configuration server require this password. Leave it blank to keep the current password.</p>
+            <label>Web password <input type="password" name="web_password" placeholder="Leave blank to keep current"></label>
           </fieldset>
           <button type="submit">Save and restart</button>
         </form>
@@ -432,7 +474,7 @@ def _read_request(client):
     if body_length < 0 or body_length > MAX_REQUEST_BYTES:
         raise ValueError("Request body is too large")
 
-    body = request[header_end + 4 :]
+    body = request[header_end + 4:]
     while len(body) < body_length:
         chunk = client.recv(min(512, body_length - len(body)))
         if not chunk:
@@ -442,13 +484,14 @@ def _read_request(client):
     if len(body) != body_length:
         raise ValueError("Incomplete HTTP request body")
 
-    return request_line[0], request_line[1], body.decode("utf-8")
+    return request_line[0], request_line[1], body.decode("utf-8"), headers
 
 
-def _send_response(client, status, content_type, body):
+def _send_response(client, status, content_type, body, headers=None):
     status_text = {
         200: "OK",
         400: "Bad Request",
+        401: "Unauthorized",
         404: "Not Found",
         500: "Internal Server Error",
         502: "Bad Gateway",
@@ -459,8 +502,10 @@ def _send_response(client, status, content_type, body):
         "Content-Type: {}\r\n"
         "Content-Length: {}\r\n"
         "Connection: close\r\n"
-        "\r\n"
     ).format(status, status_text, content_type, len(payload)).encode("utf-8")
+    for key, value in (headers or {}).items():
+        response += "{}: {}\r\n".format(key, value).encode("utf-8")
+    response += b"\r\n"
     _send_all(client, response + payload)
 
 
@@ -514,7 +559,7 @@ def _url_decode(value):
     while index < len(value):
         if value[index] == "%" and index + 2 < len(value):
             try:
-                result.append(int(value[index + 1 : index + 3], 16))
+                result.append(int(value[index + 1:index + 3], 16))
                 index += 3
                 continue
             except ValueError:
@@ -522,6 +567,15 @@ def _url_decode(value):
         result.extend(value[index].encode("utf-8"))
         index += 1
     return result.decode("utf-8")
+
+
+def _basic_auth_header(password):
+    credentials = (WEB_AUTH_USERNAME + ":" + str(password)).encode("utf-8")
+    if hasattr(_base64, "b2a_base64"):
+        encoded = _base64.b2a_base64(credentials).strip()
+    else:
+        encoded = _base64.b64encode(credentials)
+    return "Basic " + encoded.decode("ascii")
 
 
 def _escape_html(value):

--- a/tests/test_web_config.py
+++ b/tests/test_web_config.py
@@ -1,3 +1,4 @@
+import base64
 import json
 
 import pytest
@@ -21,6 +22,7 @@ def base_config():
         "printer": {"id": 1, "poll_interval_seconds": 3},
         "led": {"pin": 3, "flash_interval_ms": 250},
         "button": {"pin": 4, "debounce_ms": 150, "pull": "down", "trigger": "rising"},
+        "web": {"password": "old-web-password"},
     }
 
 
@@ -34,7 +36,13 @@ def valid_form():
         "printer_id": "7",
         "led_pin": "5",
         "button_pin": "6",
+        "web_password": "new-web-password",
     }
+
+
+def auth_headers(password="old-web-password"):
+    credentials = base64.b64encode(("admin:" + password).encode("utf-8")).decode("ascii")
+    return {"authorization": "Basic " + credentials}
 
 
 def test_parse_form_decodes_url_encoded_values():
@@ -83,6 +91,17 @@ def test_blank_secrets_keep_existing_values():
     assert updated["api"]["key"] == "old-key"
 
 
+def test_blank_web_password_keeps_existing_value_and_submitted_password_updates_it():
+    current = base_config()
+    form = valid_form()
+    form["web_password"] = ""
+
+    assert web_config.build_config(form, current)["web"]["password"] == "old-web-password"
+
+    form["web_password"] = "newer-web-password"
+    assert web_config.build_config(form, current)["web"]["password"] == "newer-web-password"
+
+
 @pytest.mark.parametrize(
     "field,value,error",
     [
@@ -115,6 +134,7 @@ def test_config_page_contains_form_and_does_not_require_formatting_js():
     assert 'action="/save"' in page
     assert 'name="hostname"' in page
     assert 'fetch("/api/printers", {' in page
+    assert 'name="web_password"' in page
     assert "__HOSTNAME__" not in page
 
 
@@ -123,7 +143,58 @@ def test_debug_page_does_not_expose_secrets():
 
     assert "old-password" not in page
     assert "old-key" not in page
+    assert "old-web-password" not in page
     assert "192.168.1.20" in page
+
+
+def test_all_routes_require_basic_authentication():
+    server = object.__new__(web_config.WebConfigServer)
+    server.config = base_config()
+    server.api = None
+    server.status_provider = lambda: {}
+    server.restart_requested = False
+
+    status, content_type, body = server.handle_request("GET", "/")
+
+    assert status == 401
+    assert content_type.startswith("text/html")
+    assert "Authentication required" in body
+
+
+def test_basic_authentication_allows_authenticated_requests():
+    server = object.__new__(web_config.WebConfigServer)
+    server.config = base_config()
+    server.api = None
+    server.status_provider = lambda: {}
+    server.restart_requested = False
+    credentials = base64.b64encode(b"admin:old-web-password").decode("ascii")
+
+    status, content_type, body = server.handle_request(
+        "GET",
+        "/debug",
+        headers={"authorization": "Basic " + credentials},
+    )
+
+    assert status == 200
+    assert content_type.startswith("text/html")
+    assert "Bambutton debug information" in body
+
+
+def test_basic_authentication_rejects_wrong_password():
+    server = object.__new__(web_config.WebConfigServer)
+    server.config = base_config()
+    server.api = None
+    server.status_provider = lambda: {}
+    server.restart_requested = False
+    credentials = base64.b64encode(b"admin:wrong-password").decode("ascii")
+
+    status, _, _ = server.handle_request(
+        "GET",
+        "/debug",
+        headers={"authorization": "Basic " + credentials},
+    )
+
+    assert status == 401
 
 
 def test_save_request_sets_restart_flag_and_returns_updated_page(tmp_path):
@@ -138,6 +209,7 @@ def test_save_request_sets_restart_flag_and_returns_updated_page(tmp_path):
         "POST",
         "/save",
         "&".join("{}={}".format(key, value) for key, value in valid_form().items()),
+        headers=auth_headers(),
     )
 
     assert status == 200
@@ -167,6 +239,7 @@ def test_printer_discovery_uses_submitted_api_settings():
         "POST",
         "/api/printers",
         "api_base_url=http%3A%2F%2Fnew-host%3A8000%2Fapi%2Fv1&api_key=new-key",
+        headers=auth_headers(),
     )
 
     assert status == 200


### PR DESCRIPTION
## Summary

- Require HTTP Basic authentication before serving the configuration UI, debug page, printer discovery endpoint, save endpoint, or unknown routes.
- Persist the web password in `web.password`, retain it when the password field is blank, and keep it out of debug output.
- Document the default password and add focused regression coverage for authentication and password updates.

Fixes #18

## Verification

- `/tmp/bambuddy-pytest-venv/bin/python -m pytest -q tests --ignore=tests/test_gui.py` — 22 passed
- `flake8 micro/web_config.py micro/config_loader.py tests/test_web_config.py` — passed
- Python compilation, JSON validation, and `git diff --check` — passed
- GUI tests and hardware validation were not run: the available environment is missing `pyserial`, and no ESP32-C3 board was connected.