### PR TITLE
[FEAT] Add AP fallback when Wi-Fi connection fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,16 @@ populate the printer selector from the configured API.
 Saving settings writes the board's `config.json` and restarts the firmware so
 changes such as a new Wi-Fi network or hostname take effect. The debug page
 shows current network and application state without exposing the API key or
-Wi-Fi password. If the board cannot connect to its configured Wi-Fi within the
-connection timeout, it starts a password-protected setup access point named
-`Bambutton-Setup` with password `bambutton`. Connect to that network and open
-`http://192.168.4.1/` to correct the Wi-Fi settings. Saving settings restarts
-the board so it can retry the configured network. The setup network's SSID and
-password can be changed in `wifi.ap_ssid` and `wifi.ap_password` before
-flashing the configuration.
+Wi-Fi password, or web password. All routes, including the setup access point,
+require HTTP Basic authentication using the password in `web.password`. The
+default password is `bambutton`; change it from the configuration page or in
+`config.json` before relying on the web UI. If the board cannot connect to its
+configured Wi-Fi within the connection timeout, it starts a password-protected
+setup access point named `Bambutton-Setup` with password `bambutton`. Connect
+to that network and open `http://192.168.4.1/` to correct the Wi-Fi settings.
+Saving settings restarts the board so it can retry the configured network. The
+setup network's SSID and password can be changed in `wifi.ap_ssid` and
+`wifi.ap_password` before flashing the configuration.
 
 ## Setup Assistant GUI
 
@@ -172,6 +175,9 @@ Manual users can edit `micro/config.json` before copying the files to the board:
     "debounce_ms": 150,
     "pull": "down",
     "trigger": "rising"
+  },
+  "web": {
+    "password": "change-this-password"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -84,8 +84,13 @@ populate the printer selector from the configured API.
 Saving settings writes the board's `config.json` and restarts the firmware so
 changes such as a new Wi-Fi network or hostname take effect. The debug page
 shows current network and application state without exposing the API key or
-Wi-Fi password. The page is available only on the existing Wi-Fi network; the
-firmware does not create an access point.
+Wi-Fi password. If the board cannot connect to its configured Wi-Fi within the
+connection timeout, it starts a password-protected setup access point named
+`Bambutton-Setup` with password `bambutton`. Connect to that network and open
+`http://192.168.4.1/` to correct the Wi-Fi settings. Saving settings restarts
+the board so it can retry the configured network. The setup network's SSID and
+password can be changed in `wifi.ap_ssid` and `wifi.ap_password` before
+flashing the configuration.
 
 ## Setup Assistant GUI
 
@@ -145,7 +150,9 @@ Manual users can edit `micro/config.json` before copying the files to the board:
   "wifi": {
     "ssid": "your-wifi-ssid",
     "password": "your-wifi-password",
-    "timeout_seconds": 10
+    "timeout_seconds": 10,
+    "ap_ssid": "Bambutton-Setup",
+    "ap_password": "bambutton"
   },
   "api": {
     "base_url": "http://your-server-ip:8000/api/v1",

--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ Saving settings writes the board's `config.json` and restarts the firmware so
 changes such as a new Wi-Fi network or hostname take effect. The debug page
 shows current network and application state without exposing the API key or
 Wi-Fi password, or web password. All routes, including the setup access point,
-require HTTP Basic authentication using the password in `web.password`. The
-default password is `bambutton`; change it from the configuration page or in
+require HTTP Basic authentication using username `admin` and the password in
+`web.password`. The default username is `admin` and the default password is
+`bambutton`; change the password from the configuration page or in
 `config.json` before relying on the web UI. If the board cannot connect to its
 configured Wi-Fi within the connection timeout, it starts a password-protected
 setup access point named `Bambutton-Setup` with password `bambutton`. Connect

--- a/micro/config.json
+++ b/micro/config.json
@@ -26,6 +26,6 @@
     "trigger": "rising"
   },
   "web": {
-    "password": "change-this-password"
+    "password": "bambutton"
   }
 }

--- a/micro/config.json
+++ b/micro/config.json
@@ -24,5 +24,8 @@
     "debounce_ms": 150,
     "pull": "down",
     "trigger": "rising"
+  },
+  "web": {
+    "password": "change-this-password"
   }
 }

--- a/micro/config.json
+++ b/micro/config.json
@@ -2,6 +2,8 @@
   "wifi": {
     "ssid": "YOUR WIFI SSID",
     "password": "YOUR WIFI PASSWORD",
+    "ap_ssid": "Bambutton-Setup",
+    "ap_password": "bambutton",
     "timeout_seconds": 10
   },
   "api": {

--- a/micro/config_example.json
+++ b/micro/config_example.json
@@ -3,7 +3,9 @@
     "ssid": "YOUR WIFI SSID",
     "password": "YOUR WIFI PASSWORD",
     "hostname": "bambutton",
-    "timeout_seconds": 10
+    "timeout_seconds": 10,
+    "ap_ssid": "Bambutton-Setup",
+    "ap_password": "bambutton"
   },
   "api": {
     "base_url": "http://<BAMBUDDY_IP>:<BAMBUDDY_PORT>/api/v1",

--- a/micro/config_example.json
+++ b/micro/config_example.json
@@ -25,5 +25,8 @@
     "debounce_ms": 150,
     "pull": "down",
     "trigger": "rising"
+  },
+  "web": {
+    "password": "change-this-password"
   }
 }

--- a/micro/config_loader.py
+++ b/micro/config_loader.py
@@ -32,6 +32,9 @@ DEFAULT_CONFIG = {
         "pull": "down",
         "trigger": "rising",
     },
+    "web": {
+        "password": "bambutton",
+    },
 }
 
 

--- a/micro/config_loader.py
+++ b/micro/config_loader.py
@@ -10,6 +10,8 @@ DEFAULT_CONFIG = {
         "password": "",
         "hostname": "bambutton",
         "timeout_seconds": 10,
+        "ap_ssid": "Bambutton-Setup",
+        "ap_password": "bambutton",
     },
     "api": {
         "base_url": "",

--- a/micro/main.py
+++ b/micro/main.py
@@ -71,10 +71,15 @@ network = wifi.WiFi(
     ssid=config["wifi"]["ssid"],
     password=config["wifi"]["password"],
     hostname=config["wifi"].get("hostname", wifi.DEFAULT_HOSTNAME),
+    ap_ssid=config["wifi"].get("ap_ssid", wifi.DEFAULT_AP_SSID),
+    ap_password=config["wifi"].get("ap_password", wifi.DEFAULT_AP_PASSWORD),
     status_led=None,
     timeout_seconds=config["wifi"]["timeout_seconds"],
 )
-network.connect_forever(watchdog_feed=watchdog.feed)
+network.connect_with_fallback(watchdog_feed=watchdog.feed)
+if network.is_ap_mode():
+    print("Wi-Fi unavailable; connect to the setup access point to update settings")
+    flasher.on()
 
 # -- Initialize API client --
 api = bambuddy_api.BambuddyAPI(
@@ -99,7 +104,12 @@ poll_timer.start()
 
 # --- Main loop handlers ---
 def with_network_connection(request):
-    network.ensure_connected(watchdog_feed=watchdog.feed)
+    if network.is_ap_mode():
+        raise RuntimeError("Wi-Fi setup access point is active")
+
+    network.ensure_connected(watchdog_feed=watchdog.feed, fallback_to_ap=True)
+    if network.is_ap_mode():
+        raise RuntimeError("Wi-Fi setup access point is active")
     return request()
 
 
@@ -145,6 +155,7 @@ def debug_status():
         network_config = ("unavailable: {}".format(exc),)
 
     return {
+        "Network mode": network.mode(),
         "Wi-Fi connected": network.is_connected(),
         "IP address": network_config[0] if network_config else "unavailable",
         "Awaiting plate clear": PRINTER_AWAITING_PLATE_CLEAR,
@@ -176,11 +187,11 @@ while True:
         machine.reset()
 
     # Push button press to API if pending
-    if PENDING_BUTTON_PRESS:
+    if not network.is_ap_mode() and PENDING_BUTTON_PRESS:
         handle_pending_button_press()
 
     # Check printer status
-    if PRINTER_STATUS_UPDATE_REQUIRED:
+    if not network.is_ap_mode() and PRINTER_STATUS_UPDATE_REQUIRED:
         handle_printer_status_update()
 
     time.sleep_ms(25)

--- a/micro/web_config.py
+++ b/micro/web_config.py
@@ -5,9 +5,16 @@ try:
 except ImportError:
     import json
 
+try:
+    import ubinascii as _base64
+except ImportError:
+    import base64 as _base64
+
 
 CONFIG_PATH = "config.json"
 DEFAULT_HOSTNAME = "bambutton"
+DEFAULT_WEB_PASSWORD = "bambutton"
+WEB_AUTH_USERNAME = "admin"
 MAX_REQUEST_BYTES = 8192
 
 
@@ -64,9 +71,17 @@ class WebConfigServer:
         try:
             client, _address = self.listener.accept()
             client.settimeout(0.25)
-            method, path, body = _read_request(client)
-            status, content_type, response_body = self.handle_request(method, path, body)
-            _send_response(client, status, content_type, response_body)
+            method, path, body, headers = _read_request(client)
+            status, content_type, response_body = self.handle_request(
+                method,
+                path,
+                body,
+                headers,
+            )
+            response_headers = {}
+            if status == 401:
+                response_headers["WWW-Authenticate"] = 'Basic realm="Bambutton"'
+            _send_response(client, status, content_type, response_body, response_headers)
         except OSError:
             # A non-blocking listener reports no pending connection as OSError.
             # Request-level socket errors are also safe to ignore: the next
@@ -91,7 +106,13 @@ class WebConfigServer:
         self.restart_requested = False
         return restart_requested
 
-    def handle_request(self, method, path, body=""):
+    def handle_request(self, method, path, body="", headers=None):
+        if not self._is_authorized(headers or {}):
+            return 401, "text/html; charset=utf-8", _error_page(
+                "Authentication required",
+                "Enter the configured web password to access this board.",
+            )
+
         route = path.split("?", 1)[0]
 
         if method == "GET" and route in ("/", "/index.html"):
@@ -129,6 +150,16 @@ class WebConfigServer:
 
         return 404, "text/html; charset=utf-8", _error_page("Not found", "The requested page does not exist.")
 
+    def _is_authorized(self, headers):
+        configured_password = self.config.get("web", {}).get(
+            "password",
+            DEFAULT_WEB_PASSWORD,
+        )
+        if not configured_password:
+            configured_password = DEFAULT_WEB_PASSWORD
+        expected = _basic_auth_header(configured_password)
+        return headers.get("authorization", "").strip() == expected
+
     def _get_printers(self, form):
         if not form:
             return self.api.get_printers()
@@ -165,6 +196,7 @@ def build_config(form, current_config):
     printer = config.setdefault("printer", {})
     led = config.setdefault("led", {})
     button = config.setdefault("button", {})
+    web = config.setdefault("web", {})
 
     wifi["ssid"] = _required_text(form, "wifi_ssid", wifi.get("ssid", ""), "Wi-Fi SSID")
     wifi["password"] = _optional_secret(form, "wifi_password", wifi.get("password", ""))
@@ -197,6 +229,11 @@ def build_config(form, current_config):
         raise ValueError("LED pin and button pin must be different.")
     led["pin"] = led_pin
     button["pin"] = button_pin
+    web["password"] = _optional_secret(
+        form,
+        "web_password",
+        web.get("password", DEFAULT_WEB_PASSWORD) or DEFAULT_WEB_PASSWORD,
+    )
 
     return config
 
@@ -246,6 +283,11 @@ def render_config_page(config, message=""):
             <legend>Button hardware</legend>
             <label>LED pin <input name="led_pin" inputmode="numeric" value="__LED_PIN__" required></label>
             <label>Button pin <input name="button_pin" inputmode="numeric" value="__BUTTON_PIN__" required></label>
+          </fieldset>
+          <fieldset>
+            <legend>Web authentication</legend>
+            <p>Requests to this configuration server require this password. Leave it blank to keep the current password.</p>
+            <label>Web password <input type="password" name="web_password" placeholder="Leave blank to keep current"></label>
           </fieldset>
           <button type="submit">Save and restart</button>
         </form>
@@ -442,13 +484,14 @@ def _read_request(client):
     if len(body) != body_length:
         raise ValueError("Incomplete HTTP request body")
 
-    return request_line[0], request_line[1], body.decode("utf-8")
+    return request_line[0], request_line[1], body.decode("utf-8"), headers
 
 
-def _send_response(client, status, content_type, body):
+def _send_response(client, status, content_type, body, headers=None):
     status_text = {
         200: "OK",
         400: "Bad Request",
+        401: "Unauthorized",
         404: "Not Found",
         500: "Internal Server Error",
         502: "Bad Gateway",
@@ -459,8 +502,10 @@ def _send_response(client, status, content_type, body):
         "Content-Type: {}\r\n"
         "Content-Length: {}\r\n"
         "Connection: close\r\n"
-        "\r\n"
     ).format(status, status_text, content_type, len(payload)).encode("utf-8")
+    for key, value in (headers or {}).items():
+        response += "{}: {}\r\n".format(key, value).encode("utf-8")
+    response += b"\r\n"
     _send_all(client, response + payload)
 
 
@@ -533,3 +578,12 @@ def _escape_html(value):
         .replace('"', "&quot;")
         .replace("'", "&#x27;")
     )
+
+
+def _basic_auth_header(password):
+    credentials = (WEB_AUTH_USERNAME + ":" + str(password)).encode("utf-8")
+    if hasattr(_base64, "b2a_base64"):
+        encoded = _base64.b2a_base64(credentials).strip()
+    else:
+        encoded = _base64.b64encode(credentials)
+    return "Basic " + encoded.decode("ascii")

--- a/micro/web_config.py
+++ b/micro/web_config.py
@@ -12,11 +12,11 @@ MAX_REQUEST_BYTES = 8192
 
 
 class WebConfigServer:
-    """Small LAN-only configuration server for the MicroPython board.
+    """Small polled configuration server for the MicroPython board.
 
     The server is deliberately polled from the main loop instead of running a
     second thread. That keeps configuration writes and application state in one
-    execution context and avoids adding an AP or any extra runtime service.
+    execution context while the server is available on station or AP Wi-Fi.
     """
 
     def __init__(
@@ -221,7 +221,7 @@ def render_config_page(config, message=""):
 
     content = """
         <h1>Bambutton configuration</h1>
-        <p>Configure this board over the existing Wi-Fi network. Changes are saved to the board and applied after restart.</p>
+        <p>Configure this board over Wi-Fi. Changes are saved to the board and applied after restart.</p>
         __SAVED_MESSAGE__
         <form method="post" action="/save">
           <fieldset>

--- a/micro/wifi.py
+++ b/micro/wifi.py
@@ -4,6 +4,10 @@ import time
 
 DEFAULT_HOSTNAME = "bambutton"
 RETRY_DELAY_SECONDS = 10
+DEFAULT_AP_SSID = "Bambutton-Setup"
+DEFAULT_AP_PASSWORD = "bambutton"
+STA_IF = getattr(network, "STA_IF", getattr(network.WLAN, "IF_STA", 0))
+AP_IF = getattr(network, "AP_IF", getattr(network.WLAN, "IF_AP", 1))
 
 
 class ConnectionTimeout(RuntimeError):
@@ -20,6 +24,8 @@ class WiFi:
         connected_led_value=0,
         failed_led_value=1,
         hostname=DEFAULT_HOSTNAME,
+        ap_ssid=DEFAULT_AP_SSID,
+        ap_password=DEFAULT_AP_PASSWORD,
     ):
         self.ssid = ssid
         self.password = password
@@ -28,7 +34,10 @@ class WiFi:
         self.connected_led_value = connected_led_value
         self.failed_led_value = failed_led_value
         self.hostname = hostname or DEFAULT_HOSTNAME
-        self.wlan = network.WLAN(network.STA_IF)
+        self.ap_ssid = ap_ssid or DEFAULT_AP_SSID
+        self.ap_password = ap_password or DEFAULT_AP_PASSWORD
+        self.wlan = network.WLAN(STA_IF)
+        self.ap = None
 
     def connect(self, watchdog_feed=None):
         # Set this before activating the interface so DHCP and mDNS can use it.
@@ -56,21 +65,54 @@ class WiFi:
                 self.disconnect()
                 self._sleep_before_retry(watchdog_feed)
 
-    def ensure_connected(self, watchdog_feed=None):
+    def connect_with_fallback(self, watchdog_feed=None):
+        try:
+            return self.connect(watchdog_feed=watchdog_feed)
+        except (ConnectionTimeout, OSError) as exc:
+            print("Wi-Fi connection failed:", exc)
+            self.disconnect()
+            return self.start_access_point()
+
+    def ensure_connected(self, watchdog_feed=None, fallback_to_ap=False):
+        if self.is_ap_mode():
+            return self.ap
+
         if self.is_connected():
             return self.wlan
 
         print("Wi-Fi connection lost; reconnecting")
+        if fallback_to_ap:
+            return self.connect_with_fallback(watchdog_feed=watchdog_feed)
         return self.connect_forever(watchdog_feed=watchdog_feed)
 
     def disconnect(self):
         self.wlan.disconnect()
 
     def is_connected(self):
+        if self.is_ap_mode():
+            return False
         return self.wlan.isconnected()
 
     def ifconfig(self):
+        if self.is_ap_mode():
+            return self.ap.ifconfig()
         return self.wlan.ifconfig()
+
+    def is_ap_mode(self):
+        return self.ap is not None
+
+    def mode(self):
+        return "access point" if self.is_ap_mode() else "station"
+
+    def start_access_point(self):
+        self.wlan.active(False)
+        self.ap = network.WLAN(AP_IF)
+        self.ap.active(True)
+        self.ap.config(essid=self.ap_ssid, password=self.ap_password)
+        self._set_led(self.failed_led_value)
+        print("Wi-Fi setup access point:", self.ap_ssid)
+        print("Access point config:", self.ap.ifconfig())
+        return self.ap
 
     def _wait_for_connection(self, watchdog_feed=None):
         started_at = time.ticks_ms()

--- a/tests/test_web_config.py
+++ b/tests/test_web_config.py
@@ -1,3 +1,4 @@
+import base64
 import json
 
 import pytest
@@ -21,6 +22,7 @@ def base_config():
         "printer": {"id": 1, "poll_interval_seconds": 3},
         "led": {"pin": 3, "flash_interval_ms": 250},
         "button": {"pin": 4, "debounce_ms": 150, "pull": "down", "trigger": "rising"},
+        "web": {"password": "old-web-password"},
     }
 
 
@@ -34,7 +36,13 @@ def valid_form():
         "printer_id": "7",
         "led_pin": "5",
         "button_pin": "6",
+        "web_password": "new-web-password",
     }
+
+
+def auth_headers(password="old-web-password"):
+    credentials = base64.b64encode(("admin:" + password).encode("utf-8")).decode("ascii")
+    return {"authorization": "Basic " + credentials}
 
 
 def test_parse_form_decodes_url_encoded_values():
@@ -83,6 +91,17 @@ def test_blank_secrets_keep_existing_values():
     assert updated["api"]["key"] == "old-key"
 
 
+def test_blank_web_password_keeps_existing_value_and_submitted_password_updates_it():
+    current = base_config()
+    form = valid_form()
+    form["web_password"] = ""
+
+    assert web_config.build_config(form, current)["web"]["password"] == "old-web-password"
+
+    form["web_password"] = "newer-web-password"
+    assert web_config.build_config(form, current)["web"]["password"] == "newer-web-password"
+
+
 @pytest.mark.parametrize(
     "field,value,error",
     [
@@ -115,6 +134,7 @@ def test_config_page_contains_form_and_does_not_require_formatting_js():
     assert 'action="/save"' in page
     assert 'name="hostname"' in page
     assert 'fetch("/api/printers", {' in page
+    assert 'name="web_password"' in page
     assert "__HOSTNAME__" not in page
 
 
@@ -123,7 +143,56 @@ def test_debug_page_does_not_expose_secrets():
 
     assert "old-password" not in page
     assert "old-key" not in page
+    assert "old-web-password" not in page
     assert "192.168.1.20" in page
+
+
+def test_all_routes_require_basic_authentication():
+    server = object.__new__(web_config.WebConfigServer)
+    server.config = base_config()
+    server.api = None
+    server.status_provider = lambda: {}
+    server.restart_requested = False
+
+    status, content_type, body = server.handle_request("GET", "/")
+
+    assert status == 401
+    assert content_type.startswith("text/html")
+    assert "Authentication required" in body
+
+
+def test_basic_authentication_allows_authenticated_requests():
+    server = object.__new__(web_config.WebConfigServer)
+    server.config = base_config()
+    server.api = None
+    server.status_provider = lambda: {}
+    server.restart_requested = False
+
+    status, content_type, body = server.handle_request(
+        "GET",
+        "/debug",
+        headers=auth_headers(),
+    )
+
+    assert status == 200
+    assert content_type.startswith("text/html")
+    assert "Bambutton debug information" in body
+
+
+def test_basic_authentication_rejects_wrong_password():
+    server = object.__new__(web_config.WebConfigServer)
+    server.config = base_config()
+    server.api = None
+    server.status_provider = lambda: {}
+    server.restart_requested = False
+
+    status, _, _ = server.handle_request(
+        "GET",
+        "/debug",
+        headers=auth_headers("wrong-password"),
+    )
+
+    assert status == 401
 
 
 def test_save_request_sets_restart_flag_and_returns_updated_page(tmp_path):
@@ -138,6 +207,7 @@ def test_save_request_sets_restart_flag_and_returns_updated_page(tmp_path):
         "POST",
         "/save",
         "&".join("{}={}".format(key, value) for key, value in valid_form().items()),
+        headers=auth_headers(),
     )
 
     assert status == 200
@@ -167,6 +237,7 @@ def test_printer_discovery_uses_submitted_api_settings():
         "POST",
         "/api/printers",
         "api_base_url=http%3A%2F%2Fnew-host%3A8000%2Fapi%2Fv1&api_key=new-key",
+        headers=auth_headers(),
     )
 
     assert status == 200

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -24,6 +24,7 @@ def load_wifi_module(
         PM_NONE = "pm-none"
 
         def __init__(self, interface):
+            self.interface = interface
             self.connected = False
             self.config_calls = []
 
@@ -51,12 +52,19 @@ def load_wifi_module(
             return self.connected
 
         def ifconfig(self):
+            if self.interface == 1:
+                return ("192.168.4.1", "255.255.255.0", "192.168.4.1", "192.168.4.1")
             return ("192.168.1.20", "255.255.255.0", "192.168.1.1", "192.168.1.1")
 
     def set_hostname(hostname):
         events.append(("hostname", hostname))
 
-    fake_network = SimpleNamespace(STA_IF=0, WLAN=FakeWLAN, hostname=set_hostname)
+    fake_network = SimpleNamespace(
+        STA_IF=0,
+        AP_IF=1,
+        WLAN=FakeWLAN,
+        hostname=set_hostname,
+    )
 
     def ticks_ms():
         nonlocal current_time_ms
@@ -194,3 +202,27 @@ def test_ensure_connected_retries_until_wifi_returns(monkeypatch):
     wifi.wlan.connected = False
 
     assert wifi.ensure_connected().isconnected()
+
+
+def test_connect_with_fallback_starts_setup_access_point_after_timeout(monkeypatch):
+    events = []
+    wifi_module = load_wifi_module(
+        monkeypatch,
+        events,
+        connect_results=[False],
+        tick_increment_ms=10_001,
+    )
+    wifi = wifi_module.WiFi("ssid", "password", timeout_seconds=10)
+
+    access_point = wifi.connect_with_fallback()
+
+    assert access_point.interface == 1
+    assert wifi.is_ap_mode() is True
+    assert wifi.mode() == "access point"
+    assert wifi.ifconfig()[0] == "192.168.4.1"
+    assert ("active", False) in events
+    assert ("config", {
+        "essid": "Bambutton-Setup",
+        "password": "bambutton",
+    }) in events
+    assert wifi.ensure_connected() is access_point


### PR DESCRIPTION
## Summary
- start a password-protected Bambutton-Setup access point after station Wi-Fi timeout
- keep the polled web configuration server available at 192.168.4.1
- pause Bambuddy polling while setup AP mode is active
- document and test the fallback flow

## Verification
- 19 focused tests passed: tests/test_wifi.py, tests/test_web_config.py, tests/test_packaging.py
- python3 -m py_compile passed for touched Python files
- git diff --check passed
- full suite could not collect because the environment lacks the GUI serial dependency
- no hardware validation was available

Closes #19