### PR TITLE
[FEAT] Simplify flashing utility with web GUI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Most users should use the setup assistant GUI. Release builds will be published 
 The GUI guides the user through:
 
 - Choosing either Web GUI setup or Config based setup.
-- Optionally selecting a serial port; leaving it blank auto-detects the connected ESP32-C3.
+- Automatically detecting the connected ESP32-C3; no serial port selection is required.
 - Flashing the bundled generic MicroPython firmware and application files.
 - Optionally selecting an existing `config.json` to install with the firmware.
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@ Most users should use the setup assistant GUI. Release builds will be published 
 
 The GUI guides the user through:
 
-- Selecting the MicroPython firmware `.bin`.
+- Choosing either Web GUI setup or Config based setup.
 - Selecting a connected ESP32-C3 board.
-- Entering Bambuddy API connection details.
-- Fetching printers from Bambuddy and choosing by friendly name.
-- Setting the LED pin, button pin, Wi-Fi SSID, and Wi-Fi password.
-- Flashing firmware and required code.
-- Pushing settings-only updates.
+- Flashing the bundled generic MicroPython firmware and application files.
+- Optionally selecting an existing `config.json` to install with the firmware.
+
+Web GUI setup installs the generic firmware and application without a saved
+configuration. The firmware defaults use the board's setup access point when no
+Wi-Fi connection is available. Complete the board configuration from the web
+page after flashing. Config based setup installs the selected configuration file
+directly.
 
 ### Advanced: Manual Flashing
 
@@ -63,7 +66,7 @@ Key files:
 - `scripts/push_micro.py` - copies required MicroPython files to the board with `mpremote`.
 - `scripts/run_main.py` - runs `micro/main.py` on the board without copying it as an auto-start file.
 - `scripts/build_gui.py` - builds the distributable setup assistant executable with PyInstaller.
-- `src/bambutton/gui.py` - GUI for selecting firmware, board, pins, Wi-Fi, API key, and printer.
+- `src/bambutton/gui.py` - GUI for selecting a setup mode, board, and optional configuration file.
 - `src/bambutton_config_gui.py` - compatibility launcher for running the GUI from source.
 
 The firmware sets the board's network hostname to `bambutton` before connecting to Wi-Fi,

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Most users should use the setup assistant GUI. Release builds will be published 
 The GUI guides the user through:
 
 - Choosing either Web GUI setup or Config based setup.
-- Selecting a connected ESP32-C3 board.
+- Optionally selecting a serial port; leaving it blank auto-detects the connected ESP32-C3.
 - Flashing the bundled generic MicroPython firmware and application files.
 - Optionally selecting an existing `config.json` to install with the firmware.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The GUI guides the user through:
 - Choosing either Web GUI setup or Config based setup.
 - Automatically detecting the connected ESP32-C3; no serial port selection is required.
 - Flashing the bundled generic MicroPython firmware and application files.
-- Optionally selecting an existing `config.json` to install with the firmware.
+- Selecting an existing `config.json`, or saving an example configuration to
+  edit before flashing.
 
 Web GUI setup installs the generic firmware and application without a saved
 configuration. The firmware defaults use the board's setup access point when no
@@ -66,7 +67,7 @@ Key files:
 - `scripts/push_micro.py` - copies required MicroPython files to the board with `mpremote`.
 - `scripts/run_main.py` - runs `micro/main.py` on the board without copying it as an auto-start file.
 - `scripts/build_gui.py` - builds the distributable setup assistant executable with PyInstaller.
-- `src/bambutton/gui.py` - GUI for selecting a setup mode, board, and optional configuration file.
+- `src/bambutton/gui.py` - GUI for selecting a setup mode and configuration file.
 - `src/bambutton_config_gui.py` - compatibility launcher for running the GUI from source.
 
 The firmware sets the board's network hostname to `bambutton` before connecting to Wi-Fi,

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -2,11 +2,8 @@
 import contextlib
 import io
 import json
-import re
 import sys
 import time
-import urllib.error
-import urllib.request
 from pathlib import Path
 
 import serial.tools.list_ports
@@ -26,12 +23,8 @@ else:
     RESOURCE_ROOT = SOURCE_ROOT if (SOURCE_ROOT / "micro").exists() else PACKAGE_ROOT
 
 MICRO_DIR = RESOURCE_ROOT / "micro"
-CONFIG_PATH = MICRO_DIR / "config.json"
 DEFAULT_FIRMWARE_DIR = RESOURCE_ROOT / "firmware"
-
-GPIO_MIN = 0
-GPIO_MAX = 21
-DEFAULT_HOSTNAME = "bambutton"
+FIRMWARE_RESTART_DELAY_SECONDS = 2
 
 CLEAN_BOARD_CODE = """
 import os
@@ -58,97 +51,58 @@ for name in os.listdir():
 
 
 def main():
-    window = build_window(load_existing_config())
-    printers_by_label = {}
+    window = build_window()
 
-    while True:
-        event, values = window.read(timeout=250)
-        if event in (sg.WIN_CLOSED, "Exit"):
-            break
+    try:
+        while True:
+            event, values = window.read(timeout=250)
+            if event in (sg.WIN_CLOSED, "Exit"):
+                break
 
-        update_action_states(window, values)
+            update_action_states(window, values)
 
-        if event == "-REFRESH_BOARDS-":
-            refresh_boards(window)
+            if event == "-REFRESH_BOARDS-":
+                refresh_boards(window)
 
-        elif event == "-GET_PRINTERS-":
-            try:
-                printers_by_label = fetch_printers(values)
-                labels = sorted(printers_by_label.keys())
-                window["-PRINTER-"].update(values=labels, value="", disabled=not labels)
-                sg.popup("Printers loaded." if labels else "No printers returned by the API.")
-            except Exception as exc:
-                window["-PRINTER-"].update(values=[], value="", disabled=True)
-                sg.popup_error("Could not load printers", str(exc))
-
-        elif event == "-FLASH_SETTINGS-":
-            try:
-                config = build_config(values, printers_by_label)
-                write_config(config)
-                push_config(values["-BOARD-"])
-                sg.popup("Settings pushed to board.")
-            except Exception as exc:
-                sg.popup_error("Could not flash settings", str(exc))
-
-        elif event == "-FLASH_FIRMWARE-":
-            try:
-                config = build_config(values, printers_by_label)
-                firmware_path = validate_firmware(values["-FIRMWARE-"])
-                board = require_board(values["-BOARD-"])
-                write_config(config)
-                flash_firmware(board, firmware_path)
-                time.sleep(2)
-                push_micro_files(board, clean=True)
-                sg.popup("Firmware and project files flashed.")
-            except Exception as exc:
-                sg.popup_error("Could not flash firmware", str(exc))
-
-    window.close()
+            elif event == "-FLASH-":
+                try:
+                    board = require_board(values.get("-BOARD-"))
+                    firmware_path = validate_firmware(first_firmware_file())
+                    config_path = config_path_for_mode(values)
+                    flash_board(board, firmware_path, config_path)
+                    sg.popup("Firmware and project files flashed.")
+                except Exception as exc:
+                    sg.popup_error("Could not flash firmware", str(exc))
+    finally:
+        window.close()
 
 
-def build_window(config):
+def build_window():
     sg.theme("SystemDefault")
-
-    firmware_default = first_firmware_file()
 
     layout = [
         [
             sg.Frame(
-                "Board Firmware",
+                "Setup mode",
                 [
                     [
-                        sg.Text("Firmware .bin", size=(16, 1)),
-                        sg.Input(str(firmware_default), key="-FIRMWARE-", enable_events=True),
-                        sg.FileBrowse(
-                            file_types=(("Firmware binaries", "*.bin"), ("All files", "*.*")),
-                            initial_folder=str(DEFAULT_FIRMWARE_DIR),
-                        ),
-                    ],
-                ],
-                expand_x=True,
-            )
-        ],
-        [
-            sg.Frame(
-                "Bambuddy Config",
-                [
-                    [
-                        sg.Text("IP and port", size=(16, 1)),
-                        sg.Input(
-                            ip_port_from_base_url(config["api"]["base_url"]),
-                            key="-API_HOST-",
+                        sg.Radio(
+                            "Web GUI setup",
+                            "SETUP_MODE",
+                            default=True,
+                            key="-WEB-",
                             enable_events=True,
-                            tooltip="Example: 192.168.1.200:8000",
                         ),
+                        sg.Text("Flash generic firmware, then configure the board in its web GUI."),
                     ],
                     [
-                        sg.Text("API key", size=(16, 1)),
-                        sg.Input(config["api"]["key"], key="-API_KEY-", enable_events=True),
-                    ],
-                    [
-                        sg.Text("Printer", size=(16, 1)),
-                        sg.Combo([], key="-PRINTER-", readonly=True, disabled=True, size=(36, 1), enable_events=True),
-                        sg.Button("Get printers", key="-GET_PRINTERS-", disabled=True),
+                        sg.Radio(
+                            "Config based setup",
+                            "SETUP_MODE",
+                            key="-CONFIG-",
+                            enable_events=True,
+                        ),
+                        sg.Text("Flash generic firmware with an existing config.json file."),
                     ],
                 ],
                 expand_x=True,
@@ -156,34 +110,35 @@ def build_window(config):
         ],
         [
             sg.Frame(
-                "Board Configuration",
+                "Board",
                 [
                     [
-                        sg.Text("Board", size=(16, 1)),
+                        sg.Text("Serial port", size=(16, 1)),
                         sg.Combo([], key="-BOARD-", readonly=True, size=(36, 1), enable_events=True),
                         sg.Button("Refresh boards", key="-REFRESH_BOARDS-"),
                     ],
+                ],
+                expand_x=True,
+            )
+        ],
+        [
+            sg.Frame(
+                "Configuration file",
+                [
                     [
-                        sg.Text("LED pin", size=(16, 1)),
-                        sg.Input(str(config["led"]["pin"]), key="-LED_PIN-", size=(8, 1), enable_events=True),
-                    ],
-                    [
-                        sg.Text("Button pin", size=(16, 1)),
-                        sg.Input(str(config["button"]["pin"]), key="-BUTTON_PIN-", size=(8, 1), enable_events=True),
-                    ],
-                    [
-                        sg.Text("Hostname", size=(16, 1)),
-                        sg.Input(config["wifi"].get("hostname", DEFAULT_HOSTNAME), key="-HOSTNAME-", enable_events=True),
-                    ],
-                    [
-                        sg.Text("Wi-Fi SSID", size=(16, 1)),
-                        sg.Input(config["wifi"]["ssid"], key="-WIFI_SSID-", enable_events=True),
-                    ],
-                    [
-                        sg.Text("Wi-Fi password", size=(16, 1)),
-                        sg.Input(config["wifi"]["password"], key="-WIFI_PASSWORD-", enable_events=True),
+                        sg.Text("config.json", size=(16, 1)),
+                        sg.Input(key="-CONFIG_PATH-", enable_events=True, visible=False, expand_x=True),
+                        sg.FileBrowse(
+                            "Browse",
+                            key="-CONFIG_BROWSE-",
+                            target="-CONFIG_PATH-",
+                            file_types=(("JSON configuration", "*.json"), ("All files", "*.*")),
+                            visible=False,
+                        ),
                     ],
                 ],
+                key="-CONFIG_FRAME-",
+                visible=False,
                 expand_x=True,
             )
         ],
@@ -191,11 +146,7 @@ def build_window(config):
             sg.Frame(
                 "Flash",
                 [
-                    [
-                        sg.Button("Flash firmware", key="-FLASH_FIRMWARE-", disabled=True),
-                        sg.Button("Flash settings only", key="-FLASH_SETTINGS-", disabled=True),
-                        sg.Button("Exit"),
-                    ],
+                    [sg.Button("Flash", key="-FLASH-", disabled=True), sg.Button("Exit")],
                     [sg.Text("", key="-VALIDATION-", text_color="firebrick", size=(72, 2))],
                 ],
                 expand_x=True,
@@ -208,164 +159,58 @@ def build_window(config):
     return window
 
 
-def load_existing_config():
-    default = {
-        "wifi": {"ssid": "", "password": "", "hostname": DEFAULT_HOSTNAME, "timeout_seconds": 10},
-        "api": {"base_url": "", "key": ""},
-        "printer": {"id": 1, "poll_interval_seconds": 3},
-        "led": {"pin": 3, "flash_interval_ms": 250},
-        "button": {"pin": 4, "debounce_ms": 150, "pull": "down", "trigger": "rising"},
-    }
-
-    try:
-        with CONFIG_PATH.open() as config_file:
-            loaded = json.load(config_file)
-    except OSError:
-        return default
-
-    deep_update(default, loaded)
-    return default
-
-
-def deep_update(target, source):
-    for key, value in source.items():
-        if isinstance(value, dict) and isinstance(target.get(key), dict):
-            deep_update(target[key], value)
-        else:
-            target[key] = value
-
-
 def update_action_states(window, values):
-    if not values:
-        return
+    values = values or {}
+    config_mode = values.get("-CONFIG-", False)
 
-    errors = collect_basic_errors(values, require_printer=False)
-    can_get_printers = valid_host_port(values.get("-API_HOST-", "")) and not values.get("-API_KEY-", "").strip() == ""
-    can_flash_settings = not collect_basic_errors(values, require_printer=True, require_firmware=False)
-    can_flash_firmware = not collect_basic_errors(values, require_printer=True, require_firmware=True)
+    window["-CONFIG_FRAME-"].update(visible=config_mode)
+    window["-CONFIG_PATH-"].update(visible=config_mode)
+    window["-CONFIG_BROWSE-"].update(visible=config_mode)
 
-    window["-GET_PRINTERS-"].update(disabled=not can_get_printers)
-    window["-FLASH_SETTINGS-"].update(disabled=not can_flash_settings)
-    window["-FLASH_FIRMWARE-"].update(disabled=not can_flash_firmware)
+    errors = collect_basic_errors(values)
+    window["-FLASH-"].update(disabled=bool(errors))
     window["-VALIDATION-"].update(errors[0] if errors else "")
 
 
-def collect_basic_errors(values, require_printer=True, require_firmware=True):
+def collect_basic_errors(values):
     errors = []
 
-    if require_firmware:
+    if not values.get("-BOARD-"):
+        errors.append("Refresh boards and select a board.")
+
+    if values.get("-CONFIG-"):
         try:
-            validate_firmware(values.get("-FIRMWARE-", ""))
+            validate_config_file(values.get("-CONFIG_PATH-", ""))
         except ValueError as exc:
             errors.append(str(exc))
-
-    if not valid_host_port(values.get("-API_HOST-", "")):
-        errors.append("Enter Bambuddy IP and port as host:port.")
-
-    if not values.get("-API_KEY-", "").strip():
-        errors.append("Enter an API key.")
-
-    if require_printer and not values.get("-PRINTER-"):
-        errors.append("Load printers and select one.")
-
-    if not values.get("-BOARD-"):
-        errors.append("Refresh boards and select one.")
-
-    try:
-        led_pin = parse_pin(values.get("-LED_PIN-", ""), "LED pin")
-        button_pin = parse_pin(values.get("-BUTTON_PIN-", ""), "Button pin")
-        if led_pin == button_pin:
-            errors.append("LED pin and button pin must be different.")
-    except ValueError as exc:
-        errors.append(str(exc))
-
-    if not values.get("-WIFI_SSID-", "").strip():
-        errors.append("Enter a Wi-Fi SSID.")
-
-    if not valid_hostname(values.get("-HOSTNAME-", "")):
-        errors.append("Enter a hostname containing only letters, numbers, and hyphens.")
 
     return errors
 
 
-def fetch_printers(values):
-    api_base_url = api_base_url_from_host(values["-API_HOST-"])
-    request = urllib.request.Request(
-        route_url(api_base_url, "printers/"),
-        headers={"X-API-Key": values["-API_KEY-"].strip()},
-    )
+def config_path_for_mode(values):
+    if values.get("-CONFIG-"):
+        return validate_config_file(values.get("-CONFIG_PATH-", ""))
+
+    return None
+
+
+def validate_config_file(path):
+    config_path = Path(path).expanduser()
+    if not config_path.is_file():
+        raise ValueError("Choose a config.json file.")
+    if config_path.suffix.lower() != ".json":
+        raise ValueError("Configuration file must end in .json.")
 
     try:
-        with urllib.request.urlopen(request, timeout=10) as response:
-            body = response.read().decode("utf-8")
-    except urllib.error.HTTPError as exc:
-        raise RuntimeError("API rejected the request with status {}".format(exc.code))
-    except urllib.error.URLError as exc:
-        raise RuntimeError("Could not connect to API: {}".format(exc.reason))
+        with config_path.open() as config_file:
+            config = json.load(config_file)
+    except (OSError, ValueError):
+        raise ValueError("Configuration file must contain valid JSON.")
 
-    printers = json.loads(body)
-    if isinstance(printers, dict):
-        for key in ("printers", "results", "items"):
-            if key in printers and isinstance(printers[key], list):
-                printers = printers[key]
-                break
+    if not isinstance(config, dict):
+        raise ValueError("Configuration file must contain a JSON object.")
 
-    if not isinstance(printers, list):
-        raise RuntimeError("Printers route did not return a list.")
-
-    printers_by_label = {}
-    for printer in printers:
-        if not isinstance(printer, dict) or "id" not in printer:
-            continue
-
-        printer_id = printer["id"]
-        name = printer.get("friendly_name") or printer.get("name") or printer.get("display_name")
-        if not name:
-            name = "Printer {}".format(printer_id)
-
-        printers_by_label["{} ({})".format(name, printer_id)] = printer_id
-
-    return printers_by_label
-
-
-def build_config(values, printers_by_label):
-    selected_printer = values.get("-PRINTER-")
-    if selected_printer not in printers_by_label:
-        raise ValueError("Load printers and select one from the dropdown.")
-
-    return {
-        "wifi": {
-            "ssid": values["-WIFI_SSID-"].strip(),
-            "password": values["-WIFI_PASSWORD-"],
-            "hostname": values["-HOSTNAME-"].strip(),
-            "timeout_seconds": 10,
-        },
-        "api": {
-            "base_url": api_base_url_from_host(values["-API_HOST-"]),
-            "key": values["-API_KEY-"].strip(),
-            "request_timeout_seconds": 3,
-        },
-        "printer": {
-            "id": printers_by_label[selected_printer],
-            "poll_interval_seconds": 3,
-        },
-        "led": {
-            "pin": parse_pin(values["-LED_PIN-"], "LED pin"),
-            "flash_interval_ms": 250,
-        },
-        "button": {
-            "pin": parse_pin(values["-BUTTON_PIN-"], "Button pin"),
-            "debounce_ms": 150,
-            "pull": "down",
-            "trigger": "rising",
-        },
-    }
-
-
-def write_config(config):
-    with CONFIG_PATH.open("w") as config_file:
-        json.dump(config, config_file, indent=2)
-        config_file.write("\n")
+    return config_path
 
 
 def refresh_boards(window, show_errors=True):
@@ -382,12 +227,21 @@ def list_boards():
     boards = []
 
     for port in sorted(serial.tools.list_ports.comports()):
-        if not port.device:
-            continue
-
-        boards.append(port.device)
+        if port.device:
+            boards.append(port.device)
 
     return boards
+
+
+def flash_board(board, firmware_path, config_path):
+    board = require_board(board)
+    firmware_path = validate_firmware(firmware_path)
+    if config_path is not None:
+        config_path = validate_config_file(config_path)
+
+    flash_firmware(board, firmware_path)
+    time.sleep(FIRMWARE_RESTART_DELAY_SECONDS)
+    push_micro_files(board, config_path, clean=True)
 
 
 def flash_firmware(board, firmware_path):
@@ -406,19 +260,18 @@ def flash_firmware(board, firmware_path):
     )
 
 
-def push_config(board):
-    run_mpremote(mpremote_args(board, "cp", str(CONFIG_PATH), ":"))
-    run_mpremote(mpremote_args(board, "reset"))
+def push_micro_files(board, config_path, clean=False):
+    if config_path is not None:
+        config_path = validate_config_file(config_path)
 
-
-def push_micro_files(board, clean=False):
     if clean:
         run_mpremote(mpremote_args(board, "exec", CLEAN_BOARD_CODE))
 
-    files = sorted(MICRO_DIR.glob("*.py")) + [CONFIG_PATH]
-    for path in files:
+    for path in sorted(MICRO_DIR.glob("*.py")):
         run_mpremote(mpremote_args(board, "cp", str(path), ":"))
 
+    if config_path is not None:
+        run_mpremote(mpremote_args(board, "cp", str(config_path), ":config.json"))
     run_mpremote(mpremote_args(board, "reset"))
 
 
@@ -482,7 +335,7 @@ class CapturedText(io.StringIO):
 
 def validate_firmware(path):
     firmware_path = Path(path).expanduser()
-    if not firmware_path.exists():
+    if not firmware_path.is_file():
         raise ValueError("Choose a firmware .bin file.")
     if firmware_path.suffix.lower() != ".bin":
         raise ValueError("Firmware file must end in .bin.")
@@ -493,52 +346,6 @@ def require_board(board):
     if not board:
         raise ValueError("Refresh boards and select a board.")
     return board
-
-
-def valid_host_port(value):
-    if not value:
-        return False
-
-    return re.match(r"^[A-Za-z0-9_.-]+:[0-9]{1,5}$", value.strip()) is not None
-
-
-def valid_hostname(value):
-    if not value:
-        return False
-
-    return re.match(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$", value.strip()) is not None
-
-
-def api_base_url_from_host(host):
-    host = host.strip()
-    if not valid_host_port(host):
-        raise ValueError("Enter Bambuddy IP and port as host:port.")
-
-    return "http://" + host + "/api/v1"
-
-
-def route_url(api_base_url, route):
-    return api_base_url.rstrip("/") + "/" + route.lstrip("/")
-
-
-def ip_port_from_base_url(base_url):
-    if not base_url:
-        return ""
-
-    base_url = base_url.replace("http://", "").replace("https://", "")
-    return base_url.replace("/api/v1", "").rstrip("/")
-
-
-def parse_pin(value, label):
-    try:
-        pin = int(str(value).strip())
-    except ValueError:
-        raise ValueError("{} must be a number.".format(label))
-
-    if pin < GPIO_MIN or pin > GPIO_MAX:
-        raise ValueError("{} must be between {} and {}.".format(label, GPIO_MIN, GPIO_MAX))
-
-    return pin
 
 
 def first_firmware_file():

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -21,6 +21,7 @@ else:
     RESOURCE_ROOT = SOURCE_ROOT if (SOURCE_ROOT / "micro").exists() else PACKAGE_ROOT
 
 MICRO_DIR = RESOURCE_ROOT / "micro"
+CONFIG_EXAMPLE_PATH = MICRO_DIR / "config_example.json"
 DEFAULT_FIRMWARE_DIR = RESOURCE_ROOT / "firmware"
 FIRMWARE_RESTART_DELAY_SECONDS = 2
 
@@ -59,6 +60,9 @@ def main():
 
             if event in ("-WEB-", "-CONFIG-", "-CONFIG_PATH-", "-CONFIG_BROWSE-"):
                 update_action_states(window, values)
+
+            if event == "-SAVE_EXAMPLE-":
+                handle_save_example_config(window, values)
 
             if event == "-FLASH-":
                 handle_flash(window, values)
@@ -146,6 +150,18 @@ def build_window():
                 expand_x=True,
             ),
         ],
+        [
+            sg.Text("", size=(16, 1)),
+            sg.Button(
+                "Save example config...",
+                key="-SAVE_EXAMPLE-",
+                size=(24, 1),
+                button_color=(text_color, secondary_button_color),
+                mouseover_colors=(text_color, secondary_button_color),
+                font=("Helvetica", 10),
+                pad=(0, (2, 0)),
+            ),
+        ],
         [sg.HorizontalSeparator(color=divider_color, pad=(0, (12, 10)))],
         [
             sg.Text(
@@ -211,6 +227,34 @@ def build_window():
     return window
 
 
+def handle_save_example_config(window, values):
+    target = sg.popup_get_file(
+        "Save example configuration",
+        title="Save example configuration",
+        default_path="config.json",
+        default_extension=".json",
+        save_as=True,
+        file_types=(("JSON configuration", "*.json"), ("All files", "*.*")),
+    )
+    if not target:
+        return
+
+    try:
+        target_path = save_example_config(target)
+    except (OSError, ValueError) as exc:
+        window["-STATUS-"].update(value="Could not save the example config.")
+        sg.popup_error("Could not save example configuration", str(exc))
+        return
+
+    window["-CONFIG_PATH-"].update(value=str(target_path))
+    window["-STATUS-"].update(value="Example config saved; edit it before flashing.")
+    update_action_states(
+        window,
+        {"-CONFIG-": True, "-CONFIG_PATH-": str(target_path)},
+        update_status=False,
+    )
+
+
 def handle_flash(window, values):
     window["-FLASH-"].update(disabled=True)
     window["-STATUS-"].update(value="Flashing...")
@@ -236,6 +280,7 @@ def update_action_states(window, values, update_status=True):
 
     window["-CONFIG_PATH-"].update(disabled=not config_mode)
     window["-CONFIG_BROWSE-"].update(disabled=not config_mode)
+    window["-SAVE_EXAMPLE-"].update(disabled=not config_mode)
 
     errors = collect_basic_errors(values)
     window["-FLASH-"].update(disabled=bool(errors))
@@ -255,6 +300,15 @@ def collect_basic_errors(values):
             errors.append(str(exc))
 
     return errors
+
+
+def save_example_config(path):
+    target_path = Path(path).expanduser()
+    if target_path.suffix.lower() != ".json":
+        raise ValueError("Example configuration must end in .json.")
+
+    target_path.write_bytes(CONFIG_EXAMPLE_PATH.read_bytes())
+    return target_path
 
 
 def config_path_for_mode(values):

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -57,7 +57,8 @@ def main():
             if event in (sg.WIN_CLOSED, "Exit"):
                 break
 
-            update_action_states(window, values)
+            if event in ("-WEB-", "-CONFIG-", "-CONFIG_PATH-", "-CONFIG_BROWSE-"):
+                update_action_states(window, values)
 
             if event == "-FLASH-":
                 handle_flash(window, values)
@@ -237,10 +238,10 @@ def handle_flash(window, values):
         window["-STATUS-"].update(value="Flash complete.")
         sg.popup("Firmware and project files flashed.")
     finally:
-        update_action_states(window, values)
+        update_action_states(window, values, update_status=False)
 
 
-def update_action_states(window, values):
+def update_action_states(window, values, update_status=True):
     values = values or {}
     config_mode = values.get("-CONFIG-", False)
 
@@ -249,6 +250,10 @@ def update_action_states(window, values):
 
     errors = collect_basic_errors(values)
     window["-FLASH-"].update(disabled=bool(errors))
+
+    if update_status:
+        status = "Select a config.json file to continue." if errors else "Ready"
+        window["-STATUS-"].update(value=status)
 
 
 def collect_basic_errors(values):

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -60,13 +60,7 @@ def main():
             update_action_states(window, values)
 
             if event == "-FLASH-":
-                try:
-                    firmware_path = validate_firmware(first_firmware_file())
-                    config_path = config_path_for_mode(values)
-                    flash_board(firmware_path, config_path)
-                    sg.popup("Firmware and project files flashed.")
-                except Exception as exc:
-                    sg.popup_error("Could not flash firmware", str(exc))
+                handle_flash(window, values)
     finally:
         window.close()
 
@@ -140,6 +134,15 @@ def build_window():
                 "Flash",
                 [
                     [
+                        sg.Text(
+                            "Ready",
+                            key="-STATUS-",
+                            expand_x=True,
+                            justification="center",
+                            pad=(0, 4),
+                        )
+                    ],
+                    [
                         sg.Button(
                             "Flash",
                             key="-FLASH-",
@@ -162,6 +165,25 @@ def build_window():
     window = sg.Window("Bambutton Setup", layout, finalize=True)
     update_action_states(window, window.read(timeout=0)[1])
     return window
+
+
+def handle_flash(window, values):
+    window["-FLASH-"].update(disabled=True)
+    window["-STATUS-"].update(value="Flashing...")
+    window.refresh()
+
+    try:
+        firmware_path = validate_firmware(first_firmware_file())
+        config_path = config_path_for_mode(values)
+        flash_board(firmware_path, config_path)
+    except Exception as exc:
+        window["-STATUS-"].update(value="Flash failed; see the error dialog.")
+        sg.popup_error("Could not flash firmware", str(exc))
+    else:
+        window["-STATUS-"].update(value="Flash complete.")
+        sg.popup("Firmware and project files flashed.")
+    finally:
+        update_action_states(window, values)
 
 
 def update_action_states(window, values):

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -66,7 +66,7 @@ def main():
 
             elif event == "-FLASH-":
                 try:
-                    board = require_board(values.get("-BOARD-"))
+                    board = normalize_serial_port(values.get("-BOARD-"))
                     firmware_path = validate_firmware(first_firmware_file())
                     config_path = config_path_for_mode(values)
                     flash_board(board, firmware_path, config_path)
@@ -113,10 +113,11 @@ def build_window():
                 "Board",
                 [
                     [
-                        sg.Text("Serial port", size=(16, 1)),
-                        sg.Combo([], key="-BOARD-", readonly=True, size=(36, 1), enable_events=True),
+                        sg.Text("Serial port (optional)", size=(20, 1)),
+                        sg.Combo([], key="-BOARD-", size=(32, 1), enable_events=True),
                         sg.Button("Refresh boards", key="-REFRESH_BOARDS-"),
                     ],
+                    [sg.Text("Leave blank to auto-detect the connected ESP32-C3.")],
                 ],
                 expand_x=True,
             )
@@ -175,9 +176,6 @@ def update_action_states(window, values):
 def collect_basic_errors(values):
     errors = []
 
-    if not values.get("-BOARD-"):
-        errors.append("Refresh boards and select a board.")
-
     if values.get("-CONFIG-"):
         try:
             validate_config_file(values.get("-CONFIG_PATH-", ""))
@@ -234,7 +232,7 @@ def list_boards():
 
 
 def flash_board(board, firmware_path, config_path):
-    board = require_board(board)
+    board = normalize_serial_port(board)
     firmware_path = validate_firmware(firmware_path)
     if config_path is not None:
         config_path = validate_config_file(config_path)
@@ -245,19 +243,8 @@ def flash_board(board, firmware_path, config_path):
 
 
 def flash_firmware(board, firmware_path):
-    run_esptool(["--chip", "esp32c3", "--port", board, "erase_flash"])
-    run_esptool(
-        [
-            "--chip",
-            "esp32c3",
-            "--port",
-            board,
-            "write_flash",
-            "-z",
-            "0x0",
-            str(firmware_path),
-        ]
-    )
+    run_esptool(esptool_args(board, "erase_flash"))
+    run_esptool(esptool_args(board, "write_flash", "-z", "0x0", str(firmware_path)))
 
 
 def push_micro_files(board, config_path, clean=False):
@@ -276,7 +263,20 @@ def push_micro_files(board, config_path, clean=False):
 
 
 def mpremote_args(board, *args):
-    return ["connect", board] + list(args)
+    board = normalize_serial_port(board)
+    if board:
+        return ["connect", board] + list(args)
+
+    return list(args)
+
+
+def esptool_args(board, *args):
+    command = ["--chip", "esp32c3"]
+    board = normalize_serial_port(board)
+    if board:
+        command.extend(["--port", board])
+
+    return command + list(args)
 
 
 def run_mpremote(args, capture=False):
@@ -342,10 +342,12 @@ def validate_firmware(path):
     return firmware_path
 
 
-def require_board(board):
-    if not board:
-        raise ValueError("Refresh boards and select a board.")
-    return board
+def normalize_serial_port(board):
+    if board is None:
+        return None
+
+    board = str(board).strip()
+    return board or None
 
 
 def first_firmware_file():

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -72,7 +72,7 @@ def main():
 
 
 def build_window():
-    sg.theme("LightBlue3")
+    sg.theme("DarkBlue3")
     sg.set_options(
         font=("Helvetica", 11),
         element_padding=(8, 6),

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -72,7 +72,12 @@ def main():
 
 
 def build_window():
-    sg.theme("SystemDefault")
+    sg.theme("LightBlue3")
+    sg.set_options(
+        font=("Helvetica", 11),
+        element_padding=(6, 5),
+        margins=(18, 18),
+    )
 
     layout = [
         [
@@ -86,8 +91,14 @@ def build_window():
                             default=True,
                             key="-WEB-",
                             enable_events=True,
+                            size=(24, 1),
+                            pad=(0, 5),
                         ),
-                        sg.Text("Flash generic firmware, then configure the board in its web GUI."),
+                        sg.Text(
+                            "Flash generic firmware, then configure the board in its web GUI.",
+                            expand_x=True,
+                            pad=(12, 5),
+                        ),
                     ],
                     [
                         sg.Radio(
@@ -95,10 +106,17 @@ def build_window():
                             "SETUP_MODE",
                             key="-CONFIG-",
                             enable_events=True,
+                            size=(24, 1),
+                            pad=(0, 5),
                         ),
-                        sg.Text("Flash generic firmware with an existing config.json file."),
+                        sg.Text(
+                            "Flash generic firmware with an existing config.json file.",
+                            expand_x=True,
+                            pad=(12, 5),
+                        ),
                     ],
                 ],
+                pad=(0, 8),
                 expand_x=True,
             )
         ],
@@ -120,6 +138,7 @@ def build_window():
                 ],
                 key="-CONFIG_FRAME-",
                 visible=False,
+                pad=(0, 8),
                 expand_x=True,
             )
         ],
@@ -127,9 +146,29 @@ def build_window():
             sg.Frame(
                 "Flash",
                 [
-                    [sg.Button("Flash", key="-FLASH-", disabled=True), sg.Button("Exit")],
-                    [sg.Text("", key="-VALIDATION-", text_color="firebrick", size=(72, 2))],
+                    [
+                        sg.Button(
+                            "Flash",
+                            key="-FLASH-",
+                            disabled=True,
+                            size=(12, 1),
+                            expand_x=True,
+                            pad=(0, 6),
+                        )
+                    ],
+                    [
+                        sg.Text(
+                            "",
+                            key="-VALIDATION-",
+                            text_color="firebrick",
+                            size=(72, 2),
+                            expand_x=True,
+                            pad=(0, 8),
+                        )
+                    ],
+                    [sg.Text("", expand_x=True), sg.Button("Exit", size=(12, 1), pad=(0, 6))],
                 ],
+                pad=(0, 8),
                 expand_x=True,
             )
         ],

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -66,98 +66,154 @@ def main():
 
 
 def build_window():
-    sg.theme("DarkBlue3")
+    background_color = "#F4F6F8"
+    text_color = "#172033"
+    secondary_text_color = "#526070"
+    input_background_color = "#FFFFFF"
+    divider_color = "#D7DDE5"
+    primary_button_color = "#2563EB"
+    secondary_button_color = "#E2E8F0"
+
+    sg.theme("System Default")
+    sg.theme_background_color(background_color)
+    sg.theme_element_background_color(background_color)
+    sg.theme_text_element_background_color(background_color)
+    sg.theme_text_color(text_color)
+    sg.theme_input_background_color(input_background_color)
+    sg.theme_input_text_color(text_color)
+    sg.theme_button_color(("#FFFFFF", primary_button_color))
     sg.set_options(
         font=("Helvetica", 11),
-        element_padding=(8, 6),
-        margins=(20, 20),
+        element_padding=(6, 5),
+        margins=(24, 24),
+        use_ttk_buttons=True,
+        ttk_theme="clam",
     )
 
     layout = [
         [
-            sg.Frame(
-                "Setup mode",
-                [
-                    [
-                        sg.Radio(
-                            "Web GUI setup",
-                            "SETUP_MODE",
-                            default=True,
-                            key="-WEB-",
-                            enable_events=True,
-                            size=(24, 1),
-                        ),
-                        sg.Text(
-                            "Flash generic firmware, then configure the board in its web GUI.",
-                            expand_x=True,
-                        ),
-                    ],
-                    [
-                        sg.Radio(
-                            "Config based setup",
-                            "SETUP_MODE",
-                            key="-CONFIG-",
-                            enable_events=True,
-                            size=(24, 1),
-                        ),
-                        sg.Text(
-                            "Flash generic firmware with an existing config.json file.",
-                            expand_x=True,
-                        ),
-                    ],
-                ],
-                pad=(0, 4),
-                expand_x=True,
+            sg.Text(
+                "Bambutton setup",
+                font=("Helvetica", 16, "bold"),
+                text_color=text_color,
+                pad=(0, (0, 2)),
             )
         ],
         [
-            sg.Frame(
-                "Configuration file",
-                [
-                    [
-                        sg.Text("config.json", size=(16, 1)),
-                        sg.Input(key="-CONFIG_PATH-", enable_events=True, expand_x=True),
-                        sg.FileBrowse(
-                            "Browse",
-                            key="-CONFIG_BROWSE-",
-                            target="-CONFIG_PATH-",
-                            file_types=(("JSON configuration", "*.json"), ("All files", "*.*")),
-                        ),
-                    ],
-                ],
-                pad=(0, 4),
-                expand_x=True,
+            sg.Text(
+                "Choose how to provision your board.",
+                text_color=secondary_text_color,
+                pad=(0, (0, 16)),
             )
         ],
         [
-            sg.Frame(
+            sg.Text(
+                "SETUP MODE",
+                font=("Helvetica", 10, "bold"),
+                text_color=secondary_text_color,
+                pad=(0, (0, 6)),
+            )
+        ],
+        [
+            sg.Radio(
+                "Web GUI setup",
+                "SETUP_MODE",
+                default=True,
+                key="-WEB-",
+                enable_events=True,
+                size=(24, 1),
+                text_color=text_color,
+            ),
+            sg.Text(
+                "Flash generic firmware, then configure the board in its web GUI.",
+                text_color=secondary_text_color,
+                expand_x=True,
+            ),
+        ],
+        [
+            sg.Radio(
+                "Config based setup",
+                "SETUP_MODE",
+                key="-CONFIG-",
+                enable_events=True,
+                size=(24, 1),
+                text_color=text_color,
+            ),
+            sg.Text(
+                "Flash generic firmware with an existing config.json file.",
+                text_color=secondary_text_color,
+                expand_x=True,
+            ),
+        ],
+        [
+            sg.HorizontalSeparator(color=divider_color, pad=(0, (16, 14)))
+        ],
+        [
+            sg.Text(
+                "CONFIGURATION FILE",
+                font=("Helvetica", 10, "bold"),
+                text_color=secondary_text_color,
+                pad=(0, (0, 6)),
+            )
+        ],
+        [
+            sg.Text("config.json", size=(16, 1), text_color=text_color),
+            sg.Input(
+                key="-CONFIG_PATH-",
+                enable_events=True,
+                expand_x=True,
+                background_color=input_background_color,
+                text_color=text_color,
+            ),
+            sg.FileBrowse(
+                "Browse",
+                key="-CONFIG_BROWSE-",
+                target="-CONFIG_PATH-",
+                file_types=(("JSON configuration", "*.json"), ("All files", "*.*")),
+                button_color=(text_color, secondary_button_color),
+            ),
+        ],
+        [
+            sg.HorizontalSeparator(color=divider_color, pad=(0, (16, 14)))
+        ],
+        [
+            sg.Text(
+                "FLASH",
+                font=("Helvetica", 10, "bold"),
+                text_color=secondary_text_color,
+                pad=(0, (0, 6)),
+            )
+        ],
+        [
+            sg.Text(
+                "Ready",
+                key="-STATUS-",
+                text_color=secondary_text_color,
+                expand_x=True,
+                justification="center",
+                pad=(0, (0, 12)),
+            )
+        ],
+        [
+            sg.Button(
                 "Flash",
-                [
-                    [
-                        sg.Text(
-                            "Ready",
-                            key="-STATUS-",
-                            expand_x=True,
-                            justification="center",
-                            pad=(0, 4),
-                        )
-                    ],
-                    [
-                        sg.Button(
-                            "Flash",
-                            key="-FLASH-",
-                            disabled=True,
-                            size=(12, 1),
-                            expand_x=True,
-                            pad=(0, 4),
-                        )
-                    ],
-                    [
-                        sg.Button("Exit", size=(12, 1), expand_x=True, pad=(0, 4))
-                    ],
-                ],
-                pad=(0, 4),
+                key="-FLASH-",
+                disabled=True,
+                size=(12, 2),
                 expand_x=True,
+                pad=(0, (0, 8)),
+                button_color=("#FFFFFF", primary_button_color),
+                font=("Helvetica", 11, "bold"),
+            )
+        ],
+        [
+            sg.Button(
+                "Exit",
+                size=(12, 2),
+                expand_x=True,
+                pad=(0, 0),
+                button_color=(text_color, secondary_button_color),
+                font=("Helvetica", 11, "bold"),
             )
         ],
     ]

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -75,8 +75,8 @@ def build_window():
     sg.theme("LightBlue3")
     sg.set_options(
         font=("Helvetica", 11),
-        element_padding=(6, 5),
-        margins=(18, 18),
+        element_padding=(8, 6),
+        margins=(20, 20),
     )
 
     layout = [
@@ -92,12 +92,10 @@ def build_window():
                             key="-WEB-",
                             enable_events=True,
                             size=(24, 1),
-                            pad=(0, 5),
                         ),
                         sg.Text(
                             "Flash generic firmware, then configure the board in its web GUI.",
                             expand_x=True,
-                            pad=(12, 5),
                         ),
                     ],
                     [
@@ -107,16 +105,14 @@ def build_window():
                             key="-CONFIG-",
                             enable_events=True,
                             size=(24, 1),
-                            pad=(0, 5),
                         ),
                         sg.Text(
                             "Flash generic firmware with an existing config.json file.",
                             expand_x=True,
-                            pad=(12, 5),
                         ),
                     ],
                 ],
-                pad=(0, 8),
+                pad=(0, 4),
                 expand_x=True,
             )
         ],
@@ -126,19 +122,16 @@ def build_window():
                 [
                     [
                         sg.Text("config.json", size=(16, 1)),
-                        sg.Input(key="-CONFIG_PATH-", enable_events=True, visible=False, expand_x=True),
+                        sg.Input(key="-CONFIG_PATH-", enable_events=True, expand_x=True),
                         sg.FileBrowse(
                             "Browse",
                             key="-CONFIG_BROWSE-",
                             target="-CONFIG_PATH-",
                             file_types=(("JSON configuration", "*.json"), ("All files", "*.*")),
-                            visible=False,
                         ),
                     ],
                 ],
-                key="-CONFIG_FRAME-",
-                visible=False,
-                pad=(0, 8),
+                pad=(0, 4),
                 expand_x=True,
             )
         ],
@@ -153,22 +146,14 @@ def build_window():
                             disabled=True,
                             size=(12, 1),
                             expand_x=True,
-                            pad=(0, 6),
+                            pad=(0, 4),
                         )
                     ],
                     [
-                        sg.Text(
-                            "",
-                            key="-VALIDATION-",
-                            text_color="firebrick",
-                            size=(72, 2),
-                            expand_x=True,
-                            pad=(0, 8),
-                        )
+                        sg.Button("Exit", size=(12, 1), expand_x=True, pad=(0, 4))
                     ],
-                    [sg.Text("", expand_x=True), sg.Button("Exit", size=(12, 1), pad=(0, 6))],
                 ],
-                pad=(0, 8),
+                pad=(0, 4),
                 expand_x=True,
             )
         ],
@@ -183,13 +168,11 @@ def update_action_states(window, values):
     values = values or {}
     config_mode = values.get("-CONFIG-", False)
 
-    window["-CONFIG_FRAME-"].update(visible=config_mode)
-    window["-CONFIG_PATH-"].update(visible=config_mode)
-    window["-CONFIG_BROWSE-"].update(visible=config_mode)
+    window["-CONFIG_PATH-"].update(disabled=not config_mode)
+    window["-CONFIG_BROWSE-"].update(disabled=not config_mode)
 
     errors = collect_basic_errors(values)
     window["-FLASH-"].update(disabled=bool(errors))
-    window["-VALIDATION-"].update(errors[0] if errors else "")
 
 
 def collect_basic_errors(values):

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -54,7 +54,7 @@ def main():
     try:
         while True:
             event, values = window.read(timeout=250)
-            if event in (sg.WIN_CLOSED, "Exit"):
+            if event == sg.WIN_CLOSED:
                 break
 
             if event in ("-WEB-", "-CONFIG-", "-CONFIG_PATH-", "-CONFIG_BROWSE-"):
@@ -201,17 +201,6 @@ def build_window():
                 pad=(0, (0, 6)),
                 button_color=("#FFFFFF", primary_button_color),
                 mouseover_colors=("#FFFFFF", primary_button_color),
-                font=("Helvetica", 10, "bold"),
-            )
-        ],
-        [
-            sg.Button(
-                "Exit",
-                size=(12, 1),
-                expand_x=True,
-                pad=(0, 0),
-                button_color=(text_color, secondary_button_color),
-                mouseover_colors=(text_color, secondary_button_color),
                 font=("Helvetica", 10, "bold"),
             )
         ],

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -66,15 +66,15 @@ def main():
 
 
 def build_window():
-    background_color = "#F4F6F8"
-    text_color = "#172033"
-    secondary_text_color = "#526070"
-    input_background_color = "#FFFFFF"
-    divider_color = "#D7DDE5"
+    background_color = "#181C23"
+    text_color = "#F3F4F6"
+    secondary_text_color = "#AAB4C3"
+    input_background_color = "#252B34"
+    divider_color = "#343B47"
     primary_button_color = "#2563EB"
-    secondary_button_color = "#E2E8F0"
+    secondary_button_color = "#2B313B"
 
-    sg.theme("System Default")
+    sg.theme("DarkGrey13")
     sg.theme_background_color(background_color)
     sg.theme_element_background_color(background_color)
     sg.theme_text_element_background_color(background_color)
@@ -83,9 +83,9 @@ def build_window():
     sg.theme_input_text_color(text_color)
     sg.theme_button_color(("#FFFFFF", primary_button_color))
     sg.set_options(
-        font=("Helvetica", 11),
-        element_padding=(6, 5),
-        margins=(24, 24),
+        font=("Helvetica", 10),
+        element_padding=(5, 4),
+        margins=(18, 16),
         use_ttk_buttons=True,
         ttk_theme="clam",
     )
@@ -94,7 +94,7 @@ def build_window():
         [
             sg.Text(
                 "Bambutton setup",
-                font=("Helvetica", 16, "bold"),
+                font=("Helvetica", 14, "bold"),
                 text_color=text_color,
                 pad=(0, (0, 2)),
             )
@@ -103,15 +103,15 @@ def build_window():
             sg.Text(
                 "Choose how to provision your board.",
                 text_color=secondary_text_color,
-                pad=(0, (0, 16)),
+                pad=(0, (0, 12)),
             )
         ],
         [
             sg.Text(
                 "SETUP MODE",
-                font=("Helvetica", 10, "bold"),
+                font=("Helvetica", 9, "bold"),
                 text_color=secondary_text_color,
-                pad=(0, (0, 6)),
+                pad=(0, (0, 4)),
             )
         ],
         [
@@ -125,7 +125,7 @@ def build_window():
                 text_color=text_color,
             ),
             sg.Text(
-                "Flash generic firmware, then configure the board in its web GUI.",
+                "Flash firmware, then configure in the web GUI.",
                 text_color=secondary_text_color,
                 expand_x=True,
             ),
@@ -140,20 +140,18 @@ def build_window():
                 text_color=text_color,
             ),
             sg.Text(
-                "Flash generic firmware with an existing config.json file.",
+                "Flash firmware with an existing config.json file.",
                 text_color=secondary_text_color,
                 expand_x=True,
             ),
         ],
-        [
-            sg.HorizontalSeparator(color=divider_color, pad=(0, (16, 14)))
-        ],
+        [sg.HorizontalSeparator(color=divider_color, pad=(0, (12, 10)))],
         [
             sg.Text(
                 "CONFIGURATION FILE",
-                font=("Helvetica", 10, "bold"),
+                font=("Helvetica", 9, "bold"),
                 text_color=secondary_text_color,
-                pad=(0, (0, 6)),
+                pad=(0, (0, 4)),
             )
         ],
         [
@@ -173,15 +171,13 @@ def build_window():
                 button_color=(text_color, secondary_button_color),
             ),
         ],
-        [
-            sg.HorizontalSeparator(color=divider_color, pad=(0, (16, 14)))
-        ],
+        [sg.HorizontalSeparator(color=divider_color, pad=(0, (12, 10)))],
         [
             sg.Text(
                 "FLASH",
-                font=("Helvetica", 10, "bold"),
+                font=("Helvetica", 9, "bold"),
                 text_color=secondary_text_color,
-                pad=(0, (0, 6)),
+                pad=(0, (0, 4)),
             )
         ],
         [
@@ -191,7 +187,7 @@ def build_window():
                 text_color=secondary_text_color,
                 expand_x=True,
                 justification="center",
-                pad=(0, (0, 12)),
+                pad=(0, (0, 8)),
             )
         ],
         [
@@ -199,21 +195,23 @@ def build_window():
                 "Flash",
                 key="-FLASH-",
                 disabled=True,
-                size=(12, 2),
+                size=(12, 1),
                 expand_x=True,
-                pad=(0, (0, 8)),
+                pad=(0, (0, 6)),
                 button_color=("#FFFFFF", primary_button_color),
-                font=("Helvetica", 11, "bold"),
+                mouseover_colors=("#FFFFFF", primary_button_color),
+                font=("Helvetica", 10, "bold"),
             )
         ],
         [
             sg.Button(
                 "Exit",
-                size=(12, 2),
+                size=(12, 1),
                 expand_x=True,
                 pad=(0, 0),
                 button_color=(text_color, secondary_button_color),
-                font=("Helvetica", 11, "bold"),
+                mouseover_colors=(text_color, secondary_button_color),
+                font=("Helvetica", 10, "bold"),
             )
         ],
     ]

--- a/src/bambutton/gui.py
+++ b/src/bambutton/gui.py
@@ -6,8 +6,6 @@ import sys
 import time
 from pathlib import Path
 
-import serial.tools.list_ports
-
 try:
     import FreeSimpleGUI as sg
 except ImportError:
@@ -61,15 +59,11 @@ def main():
 
             update_action_states(window, values)
 
-            if event == "-REFRESH_BOARDS-":
-                refresh_boards(window)
-
-            elif event == "-FLASH-":
+            if event == "-FLASH-":
                 try:
-                    board = normalize_serial_port(values.get("-BOARD-"))
                     firmware_path = validate_firmware(first_firmware_file())
                     config_path = config_path_for_mode(values)
-                    flash_board(board, firmware_path, config_path)
+                    flash_board(firmware_path, config_path)
                     sg.popup("Firmware and project files flashed.")
                 except Exception as exc:
                     sg.popup_error("Could not flash firmware", str(exc))
@@ -104,20 +98,6 @@ def build_window():
                         ),
                         sg.Text("Flash generic firmware with an existing config.json file."),
                     ],
-                ],
-                expand_x=True,
-            )
-        ],
-        [
-            sg.Frame(
-                "Board",
-                [
-                    [
-                        sg.Text("Serial port (optional)", size=(20, 1)),
-                        sg.Combo([], key="-BOARD-", size=(32, 1), enable_events=True),
-                        sg.Button("Refresh boards", key="-REFRESH_BOARDS-"),
-                    ],
-                    [sg.Text("Leave blank to auto-detect the connected ESP32-C3.")],
                 ],
                 expand_x=True,
             )
@@ -211,72 +191,42 @@ def validate_config_file(path):
     return config_path
 
 
-def refresh_boards(window, show_errors=True):
-    try:
-        boards = list_boards()
-        window["-BOARD-"].update(values=boards, value=boards[0] if len(boards) == 1 else "")
-    except Exception as exc:
-        window["-BOARD-"].update(values=[], value="")
-        if show_errors:
-            sg.popup_error("Could not list boards", str(exc))
-
-
-def list_boards():
-    boards = []
-
-    for port in sorted(serial.tools.list_ports.comports()):
-        if port.device:
-            boards.append(port.device)
-
-    return boards
-
-
-def flash_board(board, firmware_path, config_path):
-    board = normalize_serial_port(board)
+def flash_board(firmware_path, config_path):
     firmware_path = validate_firmware(firmware_path)
     if config_path is not None:
         config_path = validate_config_file(config_path)
 
-    flash_firmware(board, firmware_path)
+    flash_firmware(firmware_path)
     time.sleep(FIRMWARE_RESTART_DELAY_SECONDS)
-    push_micro_files(board, config_path, clean=True)
+    push_micro_files(config_path, clean=True)
 
 
-def flash_firmware(board, firmware_path):
-    run_esptool(esptool_args(board, "erase_flash"))
-    run_esptool(esptool_args(board, "write_flash", "-z", "0x0", str(firmware_path)))
+def flash_firmware(firmware_path):
+    run_esptool(esptool_args("erase_flash"))
+    run_esptool(esptool_args("write_flash", "-z", "0x0", str(firmware_path)))
 
 
-def push_micro_files(board, config_path, clean=False):
+def push_micro_files(config_path, clean=False):
     if config_path is not None:
         config_path = validate_config_file(config_path)
 
     if clean:
-        run_mpremote(mpremote_args(board, "exec", CLEAN_BOARD_CODE))
+        run_mpremote(mpremote_args("exec", CLEAN_BOARD_CODE))
 
     for path in sorted(MICRO_DIR.glob("*.py")):
-        run_mpremote(mpremote_args(board, "cp", str(path), ":"))
+        run_mpremote(mpremote_args("cp", str(path), ":"))
 
     if config_path is not None:
-        run_mpremote(mpremote_args(board, "cp", str(config_path), ":config.json"))
-    run_mpremote(mpremote_args(board, "reset"))
+        run_mpremote(mpremote_args("cp", str(config_path), ":config.json"))
+    run_mpremote(mpremote_args("reset"))
 
 
-def mpremote_args(board, *args):
-    board = normalize_serial_port(board)
-    if board:
-        return ["connect", board] + list(args)
-
+def mpremote_args(*args):
     return list(args)
 
 
-def esptool_args(board, *args):
-    command = ["--chip", "esp32c3"]
-    board = normalize_serial_port(board)
-    if board:
-        command.extend(["--port", board])
-
-    return command + list(args)
+def esptool_args(*args):
+    return ["--chip", "esp32c3"] + list(args)
 
 
 def run_mpremote(args, capture=False):
@@ -340,14 +290,6 @@ def validate_firmware(path):
     if firmware_path.suffix.lower() != ".bin":
         raise ValueError("Firmware file must end in .bin.")
     return firmware_path
-
-
-def normalize_serial_port(board):
-    if board is None:
-        return None
-
-    board = str(board).strip()
-    return board or None
 
 
 def first_firmware_file():

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,5 +1,9 @@
+import json
 import sys
 
+import pytest
+
+from bambutton import gui
 from bambutton.gui import run_python_entrypoint
 
 
@@ -12,3 +16,88 @@ def test_run_python_entrypoint_exposes_utf8_stream_encoding():
 
     assert result.stdout == "ok"
     assert result.stderr == "warn"
+
+
+def test_web_setup_uses_firmware_defaults_without_a_saved_config():
+    assert gui.config_path_for_mode({"-WEB-": True}) is None
+
+
+def test_config_setup_requires_a_json_object(tmp_path):
+    config_path = tmp_path / "saved-config.json"
+    config_path.write_text(json.dumps({"wifi": {"ssid": "shop"}}))
+
+    assert gui.config_path_for_mode({"-CONFIG-": True, "-CONFIG_PATH-": str(config_path)}) == config_path
+
+
+@pytest.mark.parametrize(
+    "contents,error",
+    [
+        ("not json", "valid JSON"),
+        ("[]", "JSON object"),
+    ],
+)
+def test_validate_config_file_rejects_invalid_files(tmp_path, contents, error):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(contents)
+
+    with pytest.raises(ValueError, match=error):
+        gui.validate_config_file(config_path)
+
+
+def test_push_micro_files_installs_selected_file_as_config_json(tmp_path, monkeypatch):
+    micro_dir = tmp_path / "micro"
+    micro_dir.mkdir()
+    (micro_dir / "b_module.py").write_text("# b")
+    (micro_dir / "a_module.py").write_text("# a")
+    config_path = tmp_path / "saved-config.json"
+    config_path.write_text(json.dumps({"wifi": {"ssid": "shop"}}))
+    calls = []
+
+    monkeypatch.setattr(gui, "MICRO_DIR", micro_dir)
+    monkeypatch.setattr(gui, "run_mpremote", lambda args, capture=False: calls.append(args))
+
+    gui.push_micro_files("/dev/tty.button", config_path, clean=True)
+
+    assert calls[0][:3] == ["connect", "/dev/tty.button", "exec"]
+    assert calls[1][3:] == [str(micro_dir / "a_module.py"), ":"]
+    assert calls[2][3:] == [str(micro_dir / "b_module.py"), ":"]
+    assert calls[3][3:] == [str(config_path), ":config.json"]
+    assert calls[4] == ["connect", "/dev/tty.button", "reset"]
+
+
+def test_push_micro_files_omits_config_for_web_gui_setup(tmp_path, monkeypatch):
+    micro_dir = tmp_path / "micro"
+    micro_dir.mkdir()
+    (micro_dir / "main.py").write_text("# main")
+    calls = []
+
+    monkeypatch.setattr(gui, "MICRO_DIR", micro_dir)
+    monkeypatch.setattr(gui, "run_mpremote", lambda args, capture=False: calls.append(args))
+
+    gui.push_micro_files("/dev/tty.button", None, clean=True)
+
+    assert [call[2] for call in calls] == ["exec", "cp", "reset"]
+
+
+def test_flash_board_flashes_firmware_before_application_files(tmp_path, monkeypatch):
+    firmware_path = tmp_path / "firmware.bin"
+    firmware_path.write_bytes(b"firmware")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"wifi": {}}))
+    events = []
+
+    monkeypatch.setattr(gui, "flash_firmware", lambda board, path: events.append(("firmware", board, path)))
+    monkeypatch.setattr(gui.time, "sleep", lambda seconds: events.append(("sleep", seconds)))
+    monkeypatch.setattr(
+        gui,
+        "push_micro_files",
+        lambda board, path, clean=False: events.append(("files", board, path, clean)),
+    )
+
+    gui.flash_board("/dev/tty.button", firmware_path, config_path)
+
+    assert events == [
+        ("firmware", "/dev/tty.button", firmware_path),
+        ("sleep", gui.FIRMWARE_RESTART_DELAY_SECONDS),
+        ("files", "/dev/tty.button", config_path, True),
+    ]

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -26,6 +26,43 @@ def test_web_setup_does_not_require_serial_port():
     assert gui.collect_basic_errors({"-WEB-": True}) == []
 
 
+def test_config_setup_requires_a_config_file_before_flashing():
+    assert gui.collect_basic_errors({"-CONFIG-": True}) == ["Choose a config.json file."]
+
+
+def test_update_action_states_disables_config_controls_in_web_mode(tmp_path):
+    class Element:
+        def __init__(self):
+            self.updates = []
+
+        def update(self, **kwargs):
+            self.updates.append(kwargs)
+
+    class Window:
+        def __init__(self):
+            self.elements = {key: Element() for key in ("-CONFIG_PATH-", "-CONFIG_BROWSE-", "-FLASH-")}
+
+        def __getitem__(self, key):
+            return self.elements[key]
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"wifi": {}}))
+    window = Window()
+
+    gui.update_action_states(window, {"-WEB-": True})
+    assert window.elements["-CONFIG_PATH-"].updates[-1] == {"disabled": True}
+    assert window.elements["-CONFIG_BROWSE-"].updates[-1] == {"disabled": True}
+    assert window.elements["-FLASH-"].updates[-1] == {"disabled": False}
+
+    gui.update_action_states(
+        window,
+        {"-CONFIG-": True, "-CONFIG_PATH-": str(config_path)},
+    )
+    assert window.elements["-CONFIG_PATH-"].updates[-1] == {"disabled": False}
+    assert window.elements["-CONFIG_BROWSE-"].updates[-1] == {"disabled": False}
+    assert window.elements["-FLASH-"].updates[-1] == {"disabled": False}
+
+
 def test_config_setup_requires_a_json_object(tmp_path):
     config_path = tmp_path / "saved-config.json"
     config_path.write_text(json.dumps({"wifi": {"ssid": "shop"}}))

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -63,6 +63,50 @@ def test_update_action_states_disables_config_controls_in_web_mode(tmp_path):
     assert window.elements["-FLASH-"].updates[-1] == {"disabled": False}
 
 
+def test_handle_flash_shows_progress_before_flashing(tmp_path, monkeypatch):
+    class Element:
+        def __init__(self):
+            self.updates = []
+
+        def update(self, **kwargs):
+            self.updates.append(kwargs)
+
+    class Window:
+        def __init__(self):
+            self.elements = {
+                key: Element()
+                for key in ("-CONFIG_PATH-", "-CONFIG_BROWSE-", "-FLASH-", "-STATUS-")
+            }
+            self.refresh_calls = 0
+
+        def __getitem__(self, key):
+            return self.elements[key]
+
+        def refresh(self):
+            self.refresh_calls += 1
+
+    firmware_path = tmp_path / "firmware.bin"
+    firmware_path.write_bytes(b"firmware")
+    events = []
+    window = Window()
+
+    monkeypatch.setattr(gui, "first_firmware_file", lambda: firmware_path)
+    monkeypatch.setattr(gui, "config_path_for_mode", lambda values: None)
+    monkeypatch.setattr(gui, "flash_board", lambda firmware, config: events.append((firmware, config)))
+    monkeypatch.setattr(gui.sg, "popup", lambda *args: None, raising=False)
+
+    gui.handle_flash(window, {"-WEB-": True})
+
+    assert events == [(firmware_path, None)]
+    assert window.refresh_calls == 1
+    assert window.elements["-STATUS-"].updates == [
+        {"value": "Flashing..."},
+        {"value": "Flash complete."},
+    ]
+    assert window.elements["-FLASH-"].updates[0] == {"disabled": True}
+    assert window.elements["-FLASH-"].updates[-1] == {"disabled": False}
+
+
 def test_config_setup_requires_a_json_object(tmp_path):
     config_path = tmp_path / "saved-config.json"
     config_path.write_text(json.dumps({"wifi": {"ssid": "shop"}}))

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -40,7 +40,10 @@ def test_update_action_states_disables_config_controls_in_web_mode(tmp_path):
 
     class Window:
         def __init__(self):
-            self.elements = {key: Element() for key in ("-CONFIG_PATH-", "-CONFIG_BROWSE-", "-FLASH-")}
+            self.elements = {
+                key: Element()
+                for key in ("-CONFIG_PATH-", "-CONFIG_BROWSE-", "-FLASH-", "-STATUS-")
+            }
 
         def __getitem__(self, key):
             return self.elements[key]
@@ -53,6 +56,7 @@ def test_update_action_states_disables_config_controls_in_web_mode(tmp_path):
     assert window.elements["-CONFIG_PATH-"].updates[-1] == {"disabled": True}
     assert window.elements["-CONFIG_BROWSE-"].updates[-1] == {"disabled": True}
     assert window.elements["-FLASH-"].updates[-1] == {"disabled": False}
+    assert window.elements["-STATUS-"].updates[-1] == {"value": "Ready"}
 
     gui.update_action_states(
         window,
@@ -61,6 +65,35 @@ def test_update_action_states_disables_config_controls_in_web_mode(tmp_path):
     assert window.elements["-CONFIG_PATH-"].updates[-1] == {"disabled": False}
     assert window.elements["-CONFIG_BROWSE-"].updates[-1] == {"disabled": False}
     assert window.elements["-FLASH-"].updates[-1] == {"disabled": False}
+    assert window.elements["-STATUS-"].updates[-1] == {"value": "Ready"}
+
+
+def test_update_action_states_prompts_for_config_file():
+    class Element:
+        def __init__(self):
+            self.updates = []
+
+        def update(self, **kwargs):
+            self.updates.append(kwargs)
+
+    class Window:
+        def __init__(self):
+            self.elements = {
+                key: Element()
+                for key in ("-CONFIG_PATH-", "-CONFIG_BROWSE-", "-FLASH-", "-STATUS-")
+            }
+
+        def __getitem__(self, key):
+            return self.elements[key]
+
+    window = Window()
+
+    gui.update_action_states(window, {"-CONFIG-": True})
+
+    assert window.elements["-FLASH-"].updates[-1] == {"disabled": True}
+    assert window.elements["-STATUS-"].updates[-1] == {
+        "value": "Select a config.json file to continue."
+    }
 
 
 def test_handle_flash_shows_progress_before_flashing(tmp_path, monkeypatch):

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -22,6 +22,10 @@ def test_web_setup_uses_firmware_defaults_without_a_saved_config():
     assert gui.config_path_for_mode({"-WEB-": True}) is None
 
 
+def test_serial_port_is_optional_for_web_setup():
+    assert gui.collect_basic_errors({"-WEB-": True}) == []
+
+
 def test_config_setup_requires_a_json_object(tmp_path):
     config_path = tmp_path / "saved-config.json"
     config_path.write_text(json.dumps({"wifi": {"ssid": "shop"}}))
@@ -77,6 +81,26 @@ def test_push_micro_files_omits_config_for_web_gui_setup(tmp_path, monkeypatch):
     gui.push_micro_files("/dev/tty.button", None, clean=True)
 
     assert [call[2] for call in calls] == ["exec", "cp", "reset"]
+
+
+def test_mpremote_args_uses_auto_detection_when_port_is_blank():
+    assert gui.mpremote_args("", "reset") == ["reset"]
+    assert gui.mpremote_args("/dev/tty.button", "reset") == [
+        "connect",
+        "/dev/tty.button",
+        "reset",
+    ]
+
+
+def test_esptool_args_only_includes_port_when_supplied():
+    assert gui.esptool_args(None, "erase_flash") == ["--chip", "esp32c3", "erase_flash"]
+    assert gui.esptool_args("/dev/tty.button", "erase_flash") == [
+        "--chip",
+        "esp32c3",
+        "--port",
+        "/dev/tty.button",
+        "erase_flash",
+    ]
 
 
 def test_flash_board_flashes_firmware_before_application_files(tmp_path, monkeypatch):

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -22,7 +22,7 @@ def test_web_setup_uses_firmware_defaults_without_a_saved_config():
     assert gui.config_path_for_mode({"-WEB-": True}) is None
 
 
-def test_serial_port_is_optional_for_web_setup():
+def test_web_setup_does_not_require_serial_port():
     assert gui.collect_basic_errors({"-WEB-": True}) == []
 
 
@@ -60,13 +60,13 @@ def test_push_micro_files_installs_selected_file_as_config_json(tmp_path, monkey
     monkeypatch.setattr(gui, "MICRO_DIR", micro_dir)
     monkeypatch.setattr(gui, "run_mpremote", lambda args, capture=False: calls.append(args))
 
-    gui.push_micro_files("/dev/tty.button", config_path, clean=True)
+    gui.push_micro_files(config_path, clean=True)
 
-    assert calls[0][:3] == ["connect", "/dev/tty.button", "exec"]
-    assert calls[1][3:] == [str(micro_dir / "a_module.py"), ":"]
-    assert calls[2][3:] == [str(micro_dir / "b_module.py"), ":"]
-    assert calls[3][3:] == [str(config_path), ":config.json"]
-    assert calls[4] == ["connect", "/dev/tty.button", "reset"]
+    assert calls[0][0] == "exec"
+    assert calls[1][1:] == [str(micro_dir / "a_module.py"), ":"]
+    assert calls[2][1:] == [str(micro_dir / "b_module.py"), ":"]
+    assert calls[3][1:] == [str(config_path), ":config.json"]
+    assert calls[4] == ["reset"]
 
 
 def test_push_micro_files_omits_config_for_web_gui_setup(tmp_path, monkeypatch):
@@ -78,29 +78,17 @@ def test_push_micro_files_omits_config_for_web_gui_setup(tmp_path, monkeypatch):
     monkeypatch.setattr(gui, "MICRO_DIR", micro_dir)
     monkeypatch.setattr(gui, "run_mpremote", lambda args, capture=False: calls.append(args))
 
-    gui.push_micro_files("/dev/tty.button", None, clean=True)
+    gui.push_micro_files(None, clean=True)
 
-    assert [call[2] for call in calls] == ["exec", "cp", "reset"]
-
-
-def test_mpremote_args_uses_auto_detection_when_port_is_blank():
-    assert gui.mpremote_args("", "reset") == ["reset"]
-    assert gui.mpremote_args("/dev/tty.button", "reset") == [
-        "connect",
-        "/dev/tty.button",
-        "reset",
-    ]
+    assert [call[0] for call in calls] == ["exec", "cp", "reset"]
 
 
-def test_esptool_args_only_includes_port_when_supplied():
-    assert gui.esptool_args(None, "erase_flash") == ["--chip", "esp32c3", "erase_flash"]
-    assert gui.esptool_args("/dev/tty.button", "erase_flash") == [
-        "--chip",
-        "esp32c3",
-        "--port",
-        "/dev/tty.button",
-        "erase_flash",
-    ]
+def test_mpremote_args_uses_auto_detection():
+    assert gui.mpremote_args("reset") == ["reset"]
+
+
+def test_esptool_args_uses_auto_detection():
+    assert gui.esptool_args("erase_flash") == ["--chip", "esp32c3", "erase_flash"]
 
 
 def test_flash_board_flashes_firmware_before_application_files(tmp_path, monkeypatch):
@@ -110,18 +98,18 @@ def test_flash_board_flashes_firmware_before_application_files(tmp_path, monkeyp
     config_path.write_text(json.dumps({"wifi": {}}))
     events = []
 
-    monkeypatch.setattr(gui, "flash_firmware", lambda board, path: events.append(("firmware", board, path)))
+    monkeypatch.setattr(gui, "flash_firmware", lambda path: events.append(("firmware", path)))
     monkeypatch.setattr(gui.time, "sleep", lambda seconds: events.append(("sleep", seconds)))
     monkeypatch.setattr(
         gui,
         "push_micro_files",
-        lambda board, path, clean=False: events.append(("files", board, path, clean)),
+        lambda path, clean=False: events.append(("files", path, clean)),
     )
 
-    gui.flash_board("/dev/tty.button", firmware_path, config_path)
+    gui.flash_board(firmware_path, config_path)
 
     assert events == [
-        ("firmware", "/dev/tty.button", firmware_path),
+        ("firmware", firmware_path),
         ("sleep", gui.FIRMWARE_RESTART_DELAY_SECONDS),
-        ("files", "/dev/tty.button", config_path, True),
+        ("files", config_path, True),
     ]

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -42,7 +42,13 @@ def test_update_action_states_disables_config_controls_in_web_mode(tmp_path):
         def __init__(self):
             self.elements = {
                 key: Element()
-                for key in ("-CONFIG_PATH-", "-CONFIG_BROWSE-", "-FLASH-", "-STATUS-")
+                for key in (
+                    "-CONFIG_PATH-",
+                    "-CONFIG_BROWSE-",
+                    "-SAVE_EXAMPLE-",
+                    "-FLASH-",
+                    "-STATUS-",
+                )
             }
 
         def __getitem__(self, key):
@@ -55,6 +61,7 @@ def test_update_action_states_disables_config_controls_in_web_mode(tmp_path):
     gui.update_action_states(window, {"-WEB-": True})
     assert window.elements["-CONFIG_PATH-"].updates[-1] == {"disabled": True}
     assert window.elements["-CONFIG_BROWSE-"].updates[-1] == {"disabled": True}
+    assert window.elements["-SAVE_EXAMPLE-"].updates[-1] == {"disabled": True}
     assert window.elements["-FLASH-"].updates[-1] == {"disabled": False}
     assert window.elements["-STATUS-"].updates[-1] == {"value": "Ready"}
 
@@ -64,6 +71,7 @@ def test_update_action_states_disables_config_controls_in_web_mode(tmp_path):
     )
     assert window.elements["-CONFIG_PATH-"].updates[-1] == {"disabled": False}
     assert window.elements["-CONFIG_BROWSE-"].updates[-1] == {"disabled": False}
+    assert window.elements["-SAVE_EXAMPLE-"].updates[-1] == {"disabled": False}
     assert window.elements["-FLASH-"].updates[-1] == {"disabled": False}
     assert window.elements["-STATUS-"].updates[-1] == {"value": "Ready"}
 
@@ -80,7 +88,13 @@ def test_update_action_states_prompts_for_config_file():
         def __init__(self):
             self.elements = {
                 key: Element()
-                for key in ("-CONFIG_PATH-", "-CONFIG_BROWSE-", "-FLASH-", "-STATUS-")
+                for key in (
+                    "-CONFIG_PATH-",
+                    "-CONFIG_BROWSE-",
+                    "-SAVE_EXAMPLE-",
+                    "-FLASH-",
+                    "-STATUS-",
+                )
             }
 
         def __getitem__(self, key):
@@ -96,6 +110,65 @@ def test_update_action_states_prompts_for_config_file():
     }
 
 
+def test_save_example_config_copies_template(tmp_path, monkeypatch):
+    example_path = tmp_path / "config_example.json"
+    example_path.write_text('{"wifi": {"ssid": "example"}}')
+    target_path = tmp_path / "saved" / "config.json"
+    target_path.parent.mkdir()
+
+    monkeypatch.setattr(gui, "CONFIG_EXAMPLE_PATH", example_path)
+
+    assert gui.save_example_config(target_path) == target_path
+    assert target_path.read_text() == example_path.read_text()
+
+
+def test_handle_save_example_config_populates_path(tmp_path, monkeypatch):
+    class Element:
+        def __init__(self):
+            self.updates = []
+
+        def update(self, **kwargs):
+            self.updates.append(kwargs)
+
+    class Window:
+        def __init__(self):
+            self.elements = {
+                key: Element()
+                for key in (
+                    "-CONFIG_PATH-",
+                    "-CONFIG_BROWSE-",
+                    "-SAVE_EXAMPLE-",
+                    "-FLASH-",
+                    "-STATUS-",
+                )
+            }
+
+        def __getitem__(self, key):
+            return self.elements[key]
+
+    example_path = tmp_path / "config_example.json"
+    example_path.write_text('{"wifi": {"ssid": "example"}}')
+    target_path = tmp_path / "config.json"
+    window = Window()
+
+    monkeypatch.setattr(gui, "CONFIG_EXAMPLE_PATH", example_path)
+    monkeypatch.setattr(
+        gui.sg,
+        "popup_get_file",
+        lambda *args, **kwargs: str(target_path),
+        raising=False,
+    )
+
+    gui.handle_save_example_config(window, {})
+
+    assert target_path.read_text() == example_path.read_text()
+    assert {"value": str(target_path)} in window.elements["-CONFIG_PATH-"].updates
+    assert window.elements["-STATUS-"].updates[-1] == {
+        "value": "Example config saved; edit it before flashing."
+    }
+    assert window.elements["-FLASH-"].updates[-1] == {"disabled": False}
+
+
 def test_handle_flash_shows_progress_before_flashing(tmp_path, monkeypatch):
     class Element:
         def __init__(self):
@@ -108,7 +181,13 @@ def test_handle_flash_shows_progress_before_flashing(tmp_path, monkeypatch):
         def __init__(self):
             self.elements = {
                 key: Element()
-                for key in ("-CONFIG_PATH-", "-CONFIG_BROWSE-", "-FLASH-", "-STATUS-")
+                for key in (
+                    "-CONFIG_PATH-",
+                    "-CONFIG_BROWSE-",
+                    "-SAVE_EXAMPLE-",
+                    "-FLASH-",
+                    "-STATUS-",
+                )
             }
             self.refresh_calls = 0
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -7,3 +7,4 @@ def test_release_gui_includes_all_micro_python_modules():
     build_script = runpy.run_path(str(project_root / "scripts" / "build_gui.py"))
 
     assert "web_config.py" in build_script["MICRO_FILES"]
+    assert "config_example.json" in build_script["MICRO_FILES"]


### PR DESCRIPTION
Closes #22

## Summary
- Replace the configuration-heavy desktop assistant with Web GUI setup and Config based setup modes.
- Web GUI setup flashes the bundled generic firmware and MicroPython application, leaving firmware defaults to start the setup AP.
- Config based setup validates a selected JSON object and installs it as `config.json`.
- Remove API/printer discovery, pin/Wi-Fi fields, settings-only flashing, and host-side credential writes from the flasher.
- Update setup documentation and packaging coverage.

## Verification
- `39 passed` via pytest with stubs for unavailable desktop-only imports.
- `flake8` passed for touched Python files.
- `python3 -m py_compile` passed for touched Python and MicroPython files.
- `git diff --check` passed.
- Physical ESP32-C3 flashing and GUI runtime were not available in this environment.